### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,3 +203,10 @@ Extend this table when adding a new app or package with its own guide.
 - Update the relevant `AGENTS.md` when adding endpoints, bindings, env vars, or conventions.
 - HTTP contracts live in `@repo/dtos-common`; update `worker-api` and `front-app` together.
 - Never commit secrets or real environment values.
+
+## Cursor Cloud specific instructions
+
+- **Node version (critical gotcha).** The VM's default `node` on `PATH` is a `/exec-daemon/node` shim pinned to **v22.14.0**, which is too old for `@cloudflare/vite-plugin` (it needs `node:module`'s `registerHooks`, added in Node 22.15+). The repo pins **Node 24.18.0** in `.nvmrc`. This shim shadows nvm even when `nvm use` runs. Interactive/login shells are already fixed via a snippet in `~/.bashrc` that selects nvm's Node 24 and prepends it to `PATH` (also runs `corepack enable`), so `node`/`pnpm` resolve correctly out of the box. If you ever see `does not provide an export named 'registerHooks'`, you're on Node 22 — run `nvm use 24.18.0` and prepend its bin to `PATH`.
+- **Services.** Two dev servers, started together by `make dev` (see root `AGENTS.md` Quick Start / Port Allocation): `worker-api` (Hono on Cloudflare Workers, `wrangler dev`, port **8725**) and `front-app` (React + Vite, port **5174**). Verify with `GET http://localhost:8725/api/v1/health` (returns `{"status":"ok"}`) and open `http://localhost:5174` (the home page shows a green "healthy" API indicator that live-polls `worker-api`). No secrets or `.dev.vars` are required for the current health-only surface.
+- **Production build needs an env var.** `make build` runs the SPA production build, which fails closed with `Missing production frontend env: VITE_API_BASE_URL` by design. Dev (`make dev`) does **not** need it. To build locally, pass it like CI does, e.g. `VITE_API_BASE_URL=https://example.workers.dev make build`.
+- Standard commands (install/dev/build/lint/types) are in the root `AGENTS.md` Make Commands table — use those rather than raw `pnpm`/`turbo`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the monorepo (pnpm + Turborepo + Cloudflare Workers/Hono + React/Vite) in Cursor Cloud, and documents the non-obvious startup caveats discovered during setup.

The only code change is an additive `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application source was modified.

### Key findings captured in AGENTS.md
- **Node version gotcha:** the VM's default `node` (`/exec-daemon/node`) is v22.14.0, too old for `@cloudflare/vite-plugin` (needs `node:module` `registerHooks`, Node 22.15+). The repo pins Node 24.18.0 in `.nvmrc`. Future interactive shells are fixed via a one-time `~/.bashrc` snippet that selects nvm's Node 24 and prepends it to `PATH`.
- **Services:** `worker-api` (`wrangler dev`, :8725) and `front-app` (Vite, :5174), started together by `make dev`. No secrets / `.dev.vars` required for the current health-only surface.
- **Production build** (`make build`) requires `VITE_API_BASE_URL` by design; dev does not.

### Environment setup (not in this diff)
- Update script (VM startup): idempotent Node 24 selection via nvm + `pnpm install`.
- One-time `~/.bashrc` customization on the VM to make Node 24 win over the `/exec-daemon` shim.

## Verification

- ✅ `make install` — dependencies installed
- ✅ `make ci` — lint + format + check-types all pass
- ✅ `VITE_API_BASE_URL=... make build` — production build succeeds
- ✅ `make dev` — both dev servers start (`worker-api` :8725, `front-app` :5174)
- ✅ `GET http://localhost:8725/api/v1/health` → `{"status":"ok"}`
- ✅ Browser end-to-end: home page shows green "healthy" API indicator (live poll to `worker-api`) and the counter increments 0→3

[front_app_health_and_counter_demo.mp4](https://cursor.com/agents/bc-ff44b697-edbf-4478-8c5a-e47a32befbc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffront_app_health_and_counter_demo.mp4)

[front-app showing healthy API indicator and counter at 3](https://cursor.com/agents/bc-ff44b697-edbf-4478-8c5a-e47a32befbc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffront_app_healthy_counter3.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff44b697-edbf-4478-8c5a-e47a32befbc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff44b697-edbf-4478-8c5a-e47a32befbc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

