### PR TITLE
docs(cd): harden Stage 1–2 operating guidance

### DIFF
--- a/docs/cd-operating-model.md
+++ b/docs/cd-operating-model.md
@@ -23,7 +23,7 @@ The names above are logical deployable names. Wrangler named environments create
 - Stage 1 promotion replaces the active deployment with the selected version at **100%**. Stage 2 progressive exposure starts only when a human creates a two-version deployment with the new version above 0% and below 100%, then manually changes that percentage.
 - No Stage 1 or Stage 2 action is an automated ramp. “Hold” means make no deployment change; there is no separate pause primitive.
 
-This flow assumes each production Worker has already been published once. Cloudflare does not allow `versions upload` for the first upload; bootstrap uses the normal deploy path and is outside the recurring Stage 1 merge flow.
+This flow assumes each production Worker has already been published once. Cloudflare does not allow `versions upload` for the first upload; bootstrap uses the normal deploy path before production routes/domains or user traffic are attached, and is outside the recurring Stage 1 merge flow.
 
 ### Deferred target (Stage 3+)
 
@@ -146,7 +146,7 @@ Until Flagship is wired, incomplete features stay off by code path or simply do 
 
 Stage 2 is forbidden until an operator can use all of these during the ramp:
 
-1. **Version-attributed invocation outcomes** and runtime exceptions. Workers Metrics can compare active versions; Logpush `ScriptVersion` or version metadata is the fallback evidence.
+1. **Version-attributed invocation outcomes** and runtime exceptions from a verified dashboard view, Logpush `ScriptVersion`, or version-metadata instrumentation. Do not assume the default aggregate Worker view supplies every required version dimension.
 2. **Application HTTP 5xx rate by version.** A Worker invocation can be “Success” while returning an HTTP error, so runtime error charts alone are insufficient.
 3. **Version-attributed wall/CPU time** or an explicitly instrumented response-latency SLI. Wall time includes I/O and `waitUntil`; it is not guaranteed to equal client final-byte latency. Do not label a quantile “request latency” unless that is what the source measures.
 4. **`front-app` asset 404 rate** during splits. Cloudflare recommends Analytics Engine or Logpush for this; it is not currently configured in the repository.

--- a/docs/cd-operating-model.md
+++ b/docs/cd-operating-model.md
@@ -4,7 +4,9 @@
 
 **Audience:** Engineers promoting Workers traffic, owning contracts, or designing Stage 1–2 CD workflows.
 
-**Baseline (today):** CI is verify-only; deploy is manual `turbo run deploy` → `wrangler deploy --env production`; deployables are `worker-api` (Hono gateway) and `front-app` (Vite SPA on Workers assets); shared `@repo/dtos-common` + `@repo/enums-common`; staging env blocks exist but are not the default path; no KV/R2/DO/Queues in use yet.
+**Baseline (today):** CI is verify-only; deploy is manual `turbo run deploy` → `wrangler deploy --env production`; deployables are `worker-api` (Hono gateway) and `front-app` (Vite SPA on Workers assets); shared `@repo/dtos-common` + `@repo/enums-common`; staging env blocks exist but are not the default path; no KV/R2/DO/Queues in use yet. Stage 1 upload/promote separation and all Stage 2 controls are target state, not current capability.
+
+The names above are logical deployable names. Wrangler named environments create separate production Worker resources named `<top-level-name>-production`; every record, override, promote, and rollback must use and display the actual production Worker name.
 
 **Hard distinction:** Cloudflare **Worker version / gradual deployment / version affinity / rollback** control which **binary** serves traffic. **Flagship** controls which **behavior** runs inside already-deployed code. Do not conflate them.
 
@@ -14,15 +16,18 @@
 
 ### Near-term model (Stages 1–2)
 
-**(a) Merge → version upload + manual promote.**
+**Merge → version upload + manual promote.**
 
-- On merge to `main`, eligible affected deployables get an immutable Worker **version uploaded**; traffic is **not** moved automatically.
-- A human promotes (including Stage 2 percentage ramps). Upload ≠ deploy remains the standing control plane.
-- Stage 2 still uses this model: gradual ramps, SPA version affinity, and version-diff watching are practiced under **manual** promote authority—not automated progressive safeguards yet.
+- On merge to `main`, eligible affected deployables get an immutable Worker **version uploaded**. An upload does not add that version to the active deployment and does not move production traffic.
+- A two-version deployment that assigns the new version **0%** is a separate control-plane mutation used only for production-shaped override smoke. It is not equivalent to upload and is not progressive exposure.
+- Stage 1 promotion replaces the active deployment with the selected version at **100%**. Stage 2 progressive exposure starts only when a human creates a two-version deployment with the new version above 0% and below 100%, then manually changes that percentage.
+- No Stage 1 or Stage 2 action is an automated ramp. “Hold” means make no deployment change; there is no separate pause primitive.
+
+This flow assumes each production Worker has already been published once. Cloudflare does not allow `versions upload` for the first upload; bootstrap uses the normal deploy path and is outside the recurring Stage 1 merge flow.
 
 ### Deferred target (Stage 3+)
 
-**(c) Gated full CD** — routine compute/UI may auto-ramp with metric gates; migrations, binding topology, and contract removals stay human-gated. Do not adopt (b) or (c) until Stage 1→2 exit criteria below are met.
+**Gated full CD** — routine compute/UI may auto-ramp with metric gates; migrations, binding topology, and contract removals stay human-gated. This is Stage 3+ and must not be designed into the Stage 1–2 path.
 
 ### Explicitly rejected for now
 
@@ -42,19 +47,22 @@
 
 | Unit | Role | New Worker version required when |
 |------|------|----------------------------------|
-| `worker-api` | Public HTTP gateway | App source, its Wrangler config/bindings shape, or any workspace package it bundles changes in a way Turbo would mark the app `--affected` for `build` / `deploy`. |
-| `front-app` | Vite SPA served as Workers static assets | Same rule; a Vite build must precede upload. |
+| `worker-api` | Public HTTP gateway; production resource currently resolves to `worker-api-production` | App source, version-specific Wrangler settings, or any workspace package it bundles changes in a way Turbo marks the app affected for `build`. |
+| `front-app` | Vite SPA served as Workers static assets; production resource currently resolves to `front-app-production` | Same rule; the production-environment Vite build must precede upload. |
 
 No other `worker-*` / `queue-*` / `webhook-*` / `mcp-*` apps exist yet. When they appear, each is its own deployable; this memo’s package vs runtime-edge rules still apply.
 
 ### Mapping Turbo `--affected` → “new version required”
 
-Treat Turbo’s affected graph for `build`/`deploy` as the **default deploy set**. If an app would rebuild, it needs a new uploaded version before its change can serve production traffic. If it would not rebuild, do not upload a decorative new version.
+Treat Turbo’s affected graph for `build` as the **default upload set**. If an app would rebuild, it needs a new uploaded version before its change can serve production traffic. If it would not rebuild, do not upload a decorative new version.
+
+The comparison base and head are release evidence. If CI cannot resolve the intended range or Turbo falls back to “everything changed,” fail closed: stop the upload or explicitly widen to both deployables. Never silently narrow the set. Account-level changes and Worker triggers (routes, domains, cron) are not made safe by uploading a version and require separate change control.
 
 ### Shared packages (`@repo/dtos-common`, `@repo/enums-common`)
 
-- Workspace packages are JIT-bundled into each consumer artifact. A contract change that either app imports requires **coordinated consumer versions**—default: **both** `worker-api` and `front-app` get new versions in the same promote window when the changed surface is shared wire format.
-- Single-app deploy after a shared-package change is allowed only when the change cannot affect the other consumer’s wire use (rare). When unsure, deploy both.
+- Workspace packages are JIT-bundled into each consumer artifact. A contract change that either app imports requires **coordinated consumer versions**—default: **both** `worker-api` and `front-app` get versions from the same commit and build inputs when the changed surface is shared wire format.
+- “Coordinated” is not atomic. Cloudflare deployments are per Worker; there is no multi-Worker transaction, ordering guarantee, or joint rollback. Record both version IDs before traffic moves and use the compatibility order in §6.
+- A single-app upload after a shared-package change is allowed only when the changed export is not in the other app’s artifact or wire behavior and the contract owner records that evidence. When uncertain, upload both.
 - Additive contract PRs must update producers and consumers in the **same PR** (already a Contribution rule). That PR still yields multiple uploadable versions—one per affected deployable.
 
 ### Package edges vs service-binding edges
@@ -62,11 +70,11 @@ Treat Turbo’s affected graph for `build`/`deploy` as the **default deploy set*
 | Edge type | What freezes | Skew risk |
 |-----------|--------------|-----------|
 | Package (`workspace:*`) | Build-time: each Worker/SPA freezes its dependency closure into its version | Cross-deployable only when different apps are on different versions |
-| Service binding (future) | Runtime: caller and callee ramp independently | **Expected** during gradual deploys; contracts must tolerate N/N+1; version overrides are for coordinated smoke/pin, not a substitute for expand/contract |
+| HTTP (`front-app` → `worker-api`) | Runtime: each Worker ramps independently; the SPA also freezes `VITE_API_BASE_URL` at build time | N/N+1 and already-open browser sessions must remain compatible |
 
 ### Default policy: affected-only
 
-**Always deploy only affected deployables.** Reject always-deploy-all: it widens blast radius, trains false confidence (“we redeployed everything so it must be fine”), and fights the Turbo model CI already uses.
+**Default to affected-only.** Reject routine always-deploy-all: it widens blast radius, trains false confidence (“we redeployed everything so it must be fine”), and fights the Turbo model CI already uses. Explicitly widening to both deployables is the safe response to an uncertain graph or shared-wire impact; it must be recorded, not hidden.
 
 ---
 
@@ -74,14 +82,15 @@ Treat Turbo’s affected graph for `build`/`deploy` as the **default deploy set*
 
 | Class | Auto-eligible (Stage 3+)? | Stages 1–2 promote | Forbidden on `main` without expand/contract window? |
 |-------|---------------------------|--------------------|-----------------------------------------------------|
-| Routine compute / UI | Yes, once auto-ramp gates exist | Manual promote; gradual preferred for production when risk > trivial | No |
+| Routine compute / UI | Yes, once auto-ramp gates exist | Manual promote; Stage 2 gradual path only after its prerequisites are met | No |
 | Additive contract | No until all consumers have uploaded versions that understand the addition | Manual; coordinated multi-app versions | No — but same-PR consumer updates required |
 | Breaking / removal contract | Never | Manual only after expand window complete and consumers migrated | **Yes** — expand → migrate consumers → contract |
-| Binding topology / routes / secrets shape | Never | Manual; treat as infra change, not routine promote | N/A — separate change control; do not sneak into routine PRs |
+| Binding topology / compatibility settings | Never | Manual; version-specific but not routine | N/A — separate change control; do not sneak into routine PRs |
+| Routes / domains / cron triggers / connected resources / secret contents | Never | Separate control-plane change; `versions upload` does not apply triggers and rollback must not be assumed to restore external state | N/A |
 | Storage / migration (future DO/KV/Queue/DB) | Never | Manual; disables “routine” promote path | N/A until products exist; when they do, migration PRs are explicitly labeled |
-| Emergency hotfix | Manual fast-path only | May skip gradual if delay risk exceeds cutover risk; document the skip | Contract rules still apply — hotfixes do not license silent breaks |
+| Emergency hotfix | Manual fast-path only | May skip staging or gradual if delay risk exceeds cutover risk; verification, compatibility review, and the reason remain mandatory | Contract rules still apply — hotfixes do not license silent breaks |
 
-**Classifier rule:** If a change touches wire schemas, Wrangler bindings/routes/secrets shape, or durable storage layout, it is **not** routine—even if types still pass.
+**Classifier rule:** If a change touches wire schemas, Wrangler bindings, compatibility settings, triggers, connected resources, secret contents, or durable storage layout, it is **not** routine—even if types still pass.
 
 ---
 
@@ -89,9 +98,11 @@ Treat Turbo’s affected graph for `build`/`deploy` as the **default deploy set*
 
 ### Workers gradual deployment (binary blast radius)
 
-- **When used:** Stage 2 production promotes for non-trivial changes. Prefer a short percentage ladder over immediate 100% when either app’s behavior or assets change.
-- **`front-app` affinity:** Mandatory whenever traffic is split and assets use content-hashed filenames. Set a stable `Cloudflare-Workers-Version-Key` (e.g. Transform Rule on the zone) so HTML and hashed JS/CSS stay on the same version. Without affinity, gradual SPA deploys tend to produce asset **404s**.
-- **SPA ↔ API skew:** Affinity pins **within** `front-app`. It does **not** lock `front-app` and `worker-api` to the same binary generation. HTTP contracts must tolerate N and N+1 during independent ramps. Prefer promoting additive API support before SPA clients that depend on it; reverse order for removals.
+- **When used:** Stage 2 production promotes for non-trivial changes, after the observability and affinity gates below pass. One deployment can serve at most two versions; percentages are per-request routing probabilities, not exact cohort sizes or regional ordering.
+- **`front-app` affinity:** Mandatory whenever traffic is split. Without it, HTML from one version can request a content-hashed JS/CSS file from the other version and receive a 404. The affinity key must be present on the first HTML request and every asset request. A cookie created in the first response cannot pin that first request.
+- **Current blocker:** `front-app` is assets-only on `workers.dev`. Transform Rules require a route on a zone and do not operate on `workers.dev`; the browser cannot reliably attach a custom header to top-level navigation and asset requests. A production `front-app` split is therefore forbidden until a zone route/custom domain and a tested affinity-key source exist.
+- **Key safety:** Use a dedicated random rollout identifier, not an auth/session secret, user/client/matter identifier, filename, or other privileged value. The version key participates in Workers cache partitioning and must be treated as infrastructure metadata.
+- **SPA ↔ API skew:** Affinity pins **within** `front-app`. It does **not** lock `front-app` and `worker-api` to the same generation. HTTP contracts must tolerate N/N+1 and already-loaded SPA clients. Promote additive API support to 100% before exposing a dependent SPA; for removals, stop SPA use first and retain API compatibility for the measured client-retirement window.
 
 Regional percentage-by-geography is **not** our primary lever.
 
@@ -101,27 +112,29 @@ Regional percentage-by-geography is **not** our primary lever.
 |-------|----------|
 | Evaluation authority | Prefer **`worker-api` Flagship binding** (edge-local, no outbound HTTP, no app-managed token). |
 | How `front-app` learns | API / bootstrap payload from `worker-api`. Do **not** ship Cloudflare API tokens in the browser OpenFeature client provider (docs: not recommended for public apps). |
-| App / flag ownership | One Flagship app per deployable ownership boundary (`worker-api`, `front-app`). Flags have an owner, safe default, and cleanup criterion. |
+| App / flag ownership | Organize apps by ownership boundary, but evaluate both API- and UI-owned decisions through `worker-api` while browser evaluation is unsafe. Flags have an owner, configured safe default variant, call-site fallback, and cleanup criterion. |
 | Kill-switch vs Worker rollback | See precedence table below. |
 
 **Precedence (mitigation order):**
 
 | Situation | Prefer |
 |-----------|--------|
-| New feature / path causing errors; new version otherwise healthy | **Flagship kill-switch / disable** |
+| New feature / path causing errors; new version otherwise healthy | **Flagship kill-switch / disable, if wired and proven**; expect up to 30 seconds of mixed old/new evaluations |
 | Regressed correct old behavior; no schema/storage change | **Worker version rollback** (promote prior version to 100%) |
 | Bad or irreversible storage / message schema migration | **Forward fix** (or product PITR/restore)—not blind Worker rollback |
-| Partial multi-app incompatible ramp | Pause promotes; align versions; flag off risky paths |
+| Partial multi-app incompatible ramp | Hold both Workers; align versions in compatibility order; flag off risky paths only if proven |
 
-Rollback of a Worker version does **not** revert KV/R2/DO/D1/Queue data or unbound account-level routing. Bindings attached to the rolled-back version come back with that version; **data** does not rewind.
+Rollback selects a prior version’s binding declarations but does **not** recreate or rewind connected KV/R2/DO/D1/Queue resources or data, secret contents, triggers, or account-level routing. Cloudflare can block rollback if a bound resource no longer exists or a Durable Object lifecycle change intervened.
 
 ### Flagship public-beta risk acceptance
 
-We accept Flagship (public beta) as the intended **deploy ≠ release** layer for this stack, with these safe-default rules:
+Flagship is not wired in this repository. Its public beta has no documented product SLA, so it is not a Stage 1–2 safety dependency. If adopted as the intended **deploy ≠ release** layer:
 
-- Every evaluation supplies a **safe `defaultValue`** (typed getters). Evaluation failure, missing flag, or type mismatch → **safe-off / prior-safe variant**, never fail-open into risky behavior.
-- Expect brief global mixed views after flag changes (docs: on the order of tens of seconds). Design UX and API for that window.
-- Flagship disable is not schema safety for future queues/DO/DB.
+- Typed methods return the call-site `defaultValue` for known failures such as a missing flag or type mismatch; unexpected runtime failures can still throw. Callers must convert those failures to the same safe behavior.
+- Disabling a flag returns the flag’s configured default variant; that variant must be the safe behavior. It is distinct from the typed method’s call-site fallback.
+- Changes can take up to **30 seconds** to reflect globally, during which evaluations may disagree. A kill-switch is not an instantaneous global stop.
+- Flagship disable is not schema safety for queues/DO/DB and cannot repair an incompatible binary.
+- Do not increase a Worker traffic percentage and a Flagship feature percentage for the same risky behavior at the same time. Change one exposure lever, observe it, then change the other.
 
 Until Flagship is wired, incomplete features stay off by code path or simply do not merge; do not invent a second flag SaaS for the SPA.
 
@@ -129,29 +142,33 @@ Until Flagship is wired, incomplete features stay off by code path or simply do 
 
 ## 5. Observability go/no-go bar
 
-### Minimum signals before ANY auto-ramp
+### Minimum signals for Stage 2
 
-These are also the Stage 2 practice bar for **manual** gradual promotes:
+Stage 2 is forbidden until an operator can use all of these during the ramp:
 
-1. **Version-diff** error / exception rate and latency (at least p95) comparable across the two versions in a split.
-2. **`front-app` asset 404 rate** during splits (classic affinity/skew symptom).
-3. **Opaque request IDs** correlating `front-app` → `worker-api` (and later RPC), with **no** client/matter identifiers in log lines, trace attributes, error bodies, cache keys, or URL paths.
+1. **Version-attributed invocation outcomes** and runtime exceptions. Workers Metrics can compare active versions; Logpush `ScriptVersion` or version metadata is the fallback evidence.
+2. **Application HTTP 5xx rate by version.** A Worker invocation can be “Success” while returning an HTTP error, so runtime error charts alone are insufficient.
+3. **Version-attributed wall/CPU time** or an explicitly instrumented response-latency SLI. Wall time includes I/O and `waitUntil`; it is not guaranteed to equal client final-byte latency. Do not label a quantile “request latency” unless that is what the source measures.
+4. **`front-app` asset 404 rate** during splits. Cloudflare recommends Analytics Engine or Logpush for this; it is not currently configured in the repository.
+5. **Opaque request IDs** correlating `front-app` → `worker-api`. The API emits an ID today, but the SPA does not propagate one end to end; treat correlation as an unmet prerequisite.
 
-CI green is necessary and insufficient. No promote to auto-ramp without the signals above.
+No client/matter identifier or privileged content may appear in logs, traces, metric dimensions, error bodies, cache keys, URLs, affinity keys, or Flagship context. CI green is necessary and insufficient.
 
 ### Detection and mitigation targets
 
 | Metric | Target | Justification |
 |--------|--------|---------------|
-| Time-to-detect | **≤ 5 minutes** after a ramp step | Edge activation is fast; version-diff metrics exist in platform UX; “next morning” is too late for percentage ramps. |
-| Time-to-mitigate | **≤ 15 minutes** | Human-approved Flagship kill or Worker rollback under the precedence table; matches a manual-promote on-call model. |
+| Time-to-detect | **≤ 5 minutes** after a ramp step | Internal operating objective, not a Cloudflare SLA. Recent metrics can lag; if the objective cannot be measured, hold. |
+| Time-to-mitigate | **≤ 15 minutes** | Internal drill/incident objective, not a propagation guarantee. Mitigation is not complete until the active deployment and probes are verified. |
+
+Each ramp step needs a declared minimum bake duration and sample count appropriate to traffic. If the new version has too little traffic, telemetry is delayed, or signals disagree, **hold**; lack of evidence is never permission to advance.
 
 ### Not required yet (deferred)
 
 - Full OpenTelemetry export / third-party APM as a gate
 - Automated pause/rollback robots
 - Queue depth, DLQ, or DO-specific SLIs (products not in use)
-- Perfect business SLI dashboards beyond health/ready and the signals above
+- Perfect business SLI dashboards beyond the existing health probe and the signals above
 
 ---
 
@@ -160,13 +177,15 @@ CI green is necessary and insufficient. No promote to auto-ramp without the sign
 Enforceable standing rules for HTTP DTOs in `@repo/dtos-common` (and later RPC/queue schemas in the same package):
 
 1. **Expand/contract only.** Add optional fields and additive enum members first. Consumers adopt. Removals and renames happen only after the expand window.
-2. **N and N+1 must coexist** as a standing constraint across `front-app` ↔ `worker-api` (and future service-binding pairs) whenever either side can gradual-deploy independently.
+2. **N and N+1 must coexist** across `front-app` ↔ `worker-api` whenever either side can deploy independently. Reaching 100% SPA traffic does not retire JavaScript already loaded in open tabs.
 3. **Same-PR discipline** for additive wire changes that require consumer updates; never leave `main` with a producer that emits a shape no live consumer understands—or a consumer that requires a field no live producer emits—without an explicit compatibility window.
-4. **What disables promote / future auto-ramp:**
+4. **Contract evidence is required.** Shared wire changes need HTTP contract tests or equivalent recorded producer/consumer evidence before promote. This repository has no contract test suite today; types alone do not satisfy this gate.
+5. **What disables promote / future auto-ramp:**
    - Known breaking or removal contract on `main` without a completed expand/migrate window
    - Incomplete consumer uploads for an additive contract that those consumers must understand before traffic moves
-   - Missing version-diff or `front-app` asset-404 visibility for a gradual promote path
-   - Binding topology, secrets shape, or storage/migration labeled changes treated as “routine”
+   - Missing contract evidence for a shared wire change
+   - Missing version attribution, application-5xx visibility, or `front-app` asset-404 visibility for a gradual promote path
+   - Any binding, trigger, connected-resource, secret-content, or storage/migration change treated as “routine”
 
 Privileged legal-domain data rules still apply while debugging skew: no matter/client identifiers in telemetry.
 
@@ -180,13 +199,15 @@ Privileged legal-domain data rules still apply while debugging skew: no matter/c
 - [ ] Version **upload without immediate 100% traffic** practiced until boring on a non-critical path.
 - [ ] **Rollback drill** completed (time-to-mitigate measured; “what rollback does not undo” understood).
 - [ ] Named owners for `worker-api`, `front-app`, and shared contracts.
-- [ ] Staging or preview habit is real (envs already exist in Wrangler; they are used before production promote).
+- [ ] Access-protected preview or trusted 0%-override smoke is a real habit; public preview URLs are not accepted by default.
+- [ ] Shared HTTP changes have contract evidence; the current lack of contract tests is resolved or explicitly replaced with an equally strong check.
 
 ### Stage 1 → 2
 
 - [ ] Production promotes can use **gradual percentage** splits for both deployables.
-- [ ] **Version affinity** configured for `front-app` gradual path.
-- [ ] Alerts (or equivalent watched signals) exist for **version-differential errors/latency** and **`front-app` asset 404s**.
+- [ ] `front-app` is on a zone route/custom domain and **version affinity** is verified from the first HTML request through asset fetches.
+- [ ] Alerts or a continuously staffed ramp dashboard expose version-attributed runtime failures, application 5xx, measured performance, and `front-app` asset 404s.
+- [ ] End-to-end opaque request correlation is verified without privileged identifiers.
 - [ ] Written reminder that rollback does not undo storage data / unbound config (even before those products land).
 - [ ] At least one production gradual promote rehearsed end-to-end.
 
@@ -208,36 +229,37 @@ Privileged legal-domain data rules still apply while debugging skew: no matter/c
 - Trunk-based development on `main`; `main` is kept releasable via small PRs and contract discipline.
 - External GitHub Actions + Turbo `--affected` remain the orchestration source of truth.
 - Privileged-data logging constraints remain in force.
-- Flagship public beta is acceptable for release control once wired, provided safe defaults and server-side evaluation.
-- Promote / pause / rollback authority for Stages 1–2 sits with deployable owners (or their on-call delegate); unresolved ownership blocks Stage 0→1 exit.
+- Flagship public beta may be evaluated for release control once wired, but it is not a Stage 1–2 safety dependency without an explicit fallback and accepted beta risk.
+- Promote / hold / rollback authority for Stages 1–2 sits with the deployable owner or on-call delegate. The role is decided; named assignments still block Stage 0→1 exit.
 
 ### Top risks if we follow this memo
 
 1. Shared DTO change that types pass but breaks SPA runtime assumptions while versions ramp independently.
-2. Gradual `front-app` deploy without affinity → asset 404s mistaken for “random flakes.”
-3. Treating CI green as production proof and skipping version-diff / 404 signals.
-4. Jumping to auto-ramp (model b/c) before Stage 1→2 checkboxes are real.
+2. Gradual `front-app` deploy on the current `workers.dev` posture, or without first-request affinity → asset 404s mistaken for “random flakes.”
+3. Treating runtime invocation success as application success and missing HTTP 5xx or asset 404s.
+4. Treating CI green as production proof or advancing with delayed/insufficient samples.
 5. Using Worker rollback after an irreversible storage/schema change once those products exist.
-6. Ignoring Flagship client-token constraints and embedding evaluate tokens in the SPA.
+6. Treating a public-beta Flagship kill as instantaneous or embedding its API token in the SPA.
+7. Publishing a production-bound version at a public preview URL without Access, then sending privileged smoke traffic to it.
 
-### Blocking open questions
+### Required assignments before Stage 1
 
-Only these remain organizationally blocking; everything else in this memo is decided:
+The authority model is decided, but these names are not present in the repository:
 
-1. **Who holds promote / pause / rollback authority** for `worker-api` and `front-app` in the first six months (named humans or rota)?
-2. **Who owns `@repo/dtos-common` / `@repo/enums-common`** for expand/contract window sign-off?
+1. Named deployable owner or on-call rota for `worker-api` and `front-app`.
+2. Named owner for `@repo/dtos-common` / `@repo/enums-common` expand/contract sign-off.
 
-Non-blocking (decided here): affected-only vs always-all; model (a) for Stages 1–2; TTD ≤ 5m / TTM ≤ 15m; Flagship evaluation via `worker-api` binding; reject trains / blanket 100% / Builds-as-primary.
+Affected-only, manual authority, internal TTD/TTM objectives, server-side Flagship evaluation, and rejection of trains / blanket 100% / Builds-as-primary are decided here.
 
 ---
 
 ## Decision summary
 
-1. **Stages 1–2 run model (a):** merge uploads immutable versions; humans promote (Stage 2 adds manual gradual + SPA affinity)—not auto-ramp yet.
-2. **Deploy graph is affected-only;** shared DTO/enum changes default to coordinated multi-app versions; package edges ≠ future service-binding runtime skew.
-3. **Change class gates:** routine may later auto; additive contracts coordinate; breaks/removals, bindings, and storage never auto and breaks need expand/contract on `main`.
-4. **Binary vs behavior:** Workers gradual + affinity for code blast radius; Flagship (server-side on `worker-api`) for feature kill-switch—precedence favors flag disable over version rollback when the binary is otherwise healthy.
-5. **No auto-ramp without** version-diff errors/latency, `front-app` asset-404 visibility, opaque request correlation, and ≤5m detect / ≤15m mitigate—CI green alone never authorizes production exposure policy.
+1. **Stages 1–2:** merge uploads immutable versions; humans create deployments. Stage 1 selects 100%; Stage 2 manually progresses a two-version split after affinity and observability prerequisites pass.
+2. **Deploy graph is affected-only by default;** uncertain impact widens explicitly. Shared contract versions are ordered and verified per Worker—never atomic.
+3. **Change class gates:** routine may later auto; additive contracts coordinate; removals require expand/contract plus client retirement; triggers, external resource state, bindings, and storage never ride the routine path.
+4. **Binary vs behavior:** Workers gradual + affinity control binary exposure. Flagship, if wired, controls behavior; it is beta, can take 30 seconds to propagate, and is not a schema or binary rollback.
+5. **Stage 2 stays closed without** version-attributed runtime and HTTP signals, measured performance, asset-404 visibility, first-request SPA affinity, opaque correlation, and an on-call decision path.
 
 ---
 
@@ -247,11 +269,17 @@ Non-blocking (decided here): affected-only vs always-all; model (a) for Stages 1
 - Stage 1–2 design (flows / runbooks / Stage 1 handoff): [cd-stage1-2-design.md](./cd-stage1-2-design.md)
 - [Versions & deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
 - [Deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)
+- [Preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)
+- [Version overrides](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/)
 - [Gradual deployments](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/)
 - [Version affinity](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/)
 - [Rollbacks](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/)
 - [Workers observability](https://developers.cloudflare.com/workers/observability/)
+- [Workers metrics and analytics](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/)
+- [Workers cache keys](https://developers.cloudflare.com/workers/cache/cache-keys/)
 - [Workers CI/CD](https://developers.cloudflare.com/workers/ci-cd/)
 - [Flagship](https://developers.cloudflare.com/flagship/)
+- [Flagship concepts](https://developers.cloudflare.com/flagship/concepts/)
+- [Flagship binding methods](https://developers.cloudflare.com/flagship/binding/methods/)
 - [Flagship best practices](https://developers.cloudflare.com/flagship/best-practices/)
 - [Flagship client SDK warning](https://developers.cloudflare.com/flagship/sdk/client-provider/)

--- a/docs/cd-operating-model.md
+++ b/docs/cd-operating-model.md
@@ -244,6 +244,7 @@ Non-blocking (decided here): affected-only vs always-all; model (a) for Stages 1
 ## References
 
 - Assessment (architecture): [continuous-deployment-workers.md](./continuous-deployment-workers.md) (§2, §5, §6, §8–§10)
+- Stage 1–2 design (flows / runbooks / Stage 1 handoff): [cd-stage1-2-design.md](./cd-stage1-2-design.md)
 - [Versions & deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
 - [Deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)
 - [Gradual deployments](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/)

--- a/docs/cd-operating-model.md
+++ b/docs/cd-operating-model.md
@@ -230,7 +230,7 @@ Privileged legal-domain data rules still apply while debugging skew: no matter/c
 - Near-term production surface stays `worker-api` + `front-app` on Cloudflare Workers in this pnpm/Turborepo monorepo (not the sibling FastAPI/k8s template).
 - Trunk-based development on `main`; `main` is kept releasable via small PRs and contract discipline.
 - External GitHub Actions + Turbo `--affected` remain the orchestration source of truth.
-- The credential used for version upload is treated as a production-capable principal unless Cloudflare documents and the team verifies an upload-only permission. Human promotion requires a protected boundary CI cannot invoke, or explicit acceptance and monitoring of CI’s deployment authority.
+- The credential used for version upload is a production-capable principal: Cloudflare documents broad Workers script-edit authority for version and deployment writes, not an upload-only permission. Human promotion requires a protected boundary CI cannot invoke.
 - Privileged-data logging constraints remain in force.
 - Flagship public beta may be evaluated for release control once wired, but it is not a Stage 1–2 safety dependency without an explicit fallback and accepted beta risk.
 - Promote / hold / rollback authority for Stages 1–2 sits with the deployable owner or on-call delegate. The role is decided; named assignments still block Stage 0→1 exit.
@@ -271,7 +271,7 @@ Affected-only, manual authority, internal TTD/TTM objectives, server-side Flagsh
 
 - Assessment (architecture): [continuous-deployment-workers.md](./continuous-deployment-workers.md) (§2, §5, §6, §8–§10)
 - Stage 1–2 design (flows / runbooks / Stage 1 handoff): [cd-stage1-2-design.md](./cd-stage1-2-design.md)
-- Implementation evidence (platform facts / repo map / research procedure): [cd-stage1-2-implementation-evidence.md](./cd-stage1-2-implementation-evidence.md)
+- Implementation evidence (platform facts, repo map, diagrams, release schemas, Cursor starters): [cd-stage1-2-implementation-evidence.md](./cd-stage1-2-implementation-evidence.md)
 - [Versions & deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
 - [Deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)
 - [Preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)

--- a/docs/cd-operating-model.md
+++ b/docs/cd-operating-model.md
@@ -271,6 +271,7 @@ Affected-only, manual authority, internal TTD/TTM objectives, server-side Flagsh
 
 - Assessment (architecture): [continuous-deployment-workers.md](./continuous-deployment-workers.md) (§2, §5, §6, §8–§10)
 - Stage 1–2 design (flows / runbooks / Stage 1 handoff): [cd-stage1-2-design.md](./cd-stage1-2-design.md)
+- Implementation evidence (platform facts / repo map / research procedure): [cd-stage1-2-implementation-evidence.md](./cd-stage1-2-implementation-evidence.md)
 - [Versions & deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
 - [Deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)
 - [Preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)

--- a/docs/cd-operating-model.md
+++ b/docs/cd-operating-model.md
@@ -102,6 +102,7 @@ The comparison base and head are release evidence. If CI cannot resolve the inte
 - **`front-app` affinity:** Mandatory whenever traffic is split. Without it, HTML from one version can request a content-hashed JS/CSS file from the other version and receive a 404. The affinity key must be present on the first HTML request and every asset request. A cookie created in the first response cannot pin that first request.
 - **Current blocker:** `front-app` is assets-only on `workers.dev`. Transform Rules require a route on a zone and do not operate on `workers.dev`; the browser cannot reliably attach a custom header to top-level navigation and asset requests. A production `front-app` split is therefore forbidden until a zone route/custom domain and a tested affinity-key source exist.
 - **Key safety:** Use a dedicated random rollout identifier, not an auth/session secret, user/client/matter identifier, filename, or other privileged value. The version key participates in Workers cache partitioning and must be treated as infrastructure metadata.
+- **Override safety:** A trusted zone boundary must remove or block untrusted `Cloudflare-Workers-Version-Overrides` throughout every two-version deployment. Otherwise a caller with a version ID can bypass the intended percentage.
 - **SPA ↔ API skew:** Affinity pins **within** `front-app`. It does **not** lock `front-app` and `worker-api` to the same generation. HTTP contracts must tolerate N/N+1 and already-loaded SPA clients. Promote additive API support to 100% before exposing a dependent SPA; for removals, stop SPA use first and retain API compatibility for the measured client-retirement window.
 
 Regional percentage-by-geography is **not** our primary lever.
@@ -133,6 +134,7 @@ Flagship is not wired in this repository. Its public beta has no documented prod
 - Typed methods return the call-site `defaultValue` for known failures such as a missing flag or type mismatch; unexpected runtime failures can still throw. Callers must convert those failures to the same safe behavior.
 - Disabling a flag returns the flag’s configured default variant; that variant must be the safe behavior. It is distinct from the typed method’s call-site fallback.
 - Changes can take up to **30 seconds** to reflect globally, during which evaluations may disagree. A kill-switch is not an instantaneous global stop.
+- Browser bootstrap decisions have a bounded lifetime and refresh path. Privileged operations enforce the safe decision server-side per request; a cached browser decision is never authorization.
 - Flagship disable is not schema safety for queues/DO/DB and cannot repair an incompatible binary.
 - Do not increase a Worker traffic percentage and a Flagship feature percentage for the same risky behavior at the same time. Change one exposure lever, observe it, then change the other.
 
@@ -228,6 +230,7 @@ Privileged legal-domain data rules still apply while debugging skew: no matter/c
 - Near-term production surface stays `worker-api` + `front-app` on Cloudflare Workers in this pnpm/Turborepo monorepo (not the sibling FastAPI/k8s template).
 - Trunk-based development on `main`; `main` is kept releasable via small PRs and contract discipline.
 - External GitHub Actions + Turbo `--affected` remain the orchestration source of truth.
+- The credential used for version upload is treated as a production-capable principal unless Cloudflare documents and the team verifies an upload-only permission. Human promotion requires a protected boundary CI cannot invoke, or explicit acceptance and monitoring of CI’s deployment authority.
 - Privileged-data logging constraints remain in force.
 - Flagship public beta may be evaluated for release control once wired, but it is not a Stage 1–2 safety dependency without an explicit fallback and accepted beta risk.
 - Promote / hold / rollback authority for Stages 1–2 sits with the deployable owner or on-call delegate. The role is decided; named assignments still block Stage 0→1 exit.
@@ -241,6 +244,7 @@ Privileged legal-domain data rules still apply while debugging skew: no matter/c
 5. Using Worker rollback after an irreversible storage/schema change once those products exist.
 6. Treating a public-beta Flagship kill as instantaneous or embedding its API token in the SPA.
 7. Publishing a production-bound version at a public preview URL without Access, then sending privileged smoke traffic to it.
+8. Treating workflow separation as authorization even though the CI Worker-write credential can mutate production.
 
 ### Required assignments before Stage 1
 

--- a/docs/cd-stage1-2-design.md
+++ b/docs/cd-stage1-2-design.md
@@ -388,7 +388,7 @@ Ordered conceptual work packages only—this document does not provide YAML, Wra
 3. **Scripts split** — Per-app conceptual paths: **upload** (`versions upload` for the production environment) vs **promote** (`versions deploy`). Stop treating `wrangler deploy` (upload+immediate 100%) as the recurring Stage 1 `main` path.
 4. **Build provenance** — Build `front-app` for the production Cloudflare/Vite environment, record `VITE_API_BASE_URL`, commit SHA, affected base/head, actual Worker name, and returned version ID.
 5. **CI upload job** — On `main` after verify: compute affected build graph → build → upload → publish non-secret release evidence. **No deployment mutation.**
-6. **Credential boundary** — Use a narrowly scoped Cloudflare token and account ID; never commit or log them. Cloudflare documents a generic `Workers Scripts Write` permission, not an upload-only permission. Treat the CI principal as technically capable of production deployment until a narrower permission is documented and verified. Workflow separation alone is not a security boundary: enforce promotion through a separately protected approval/broker boundary that CI cannot invoke, or explicitly accept and monitor CI as a production deployment principal.
+6. **Credential boundary** — Use a narrowly scoped Cloudflare token and account ID; never commit or log them. Cloudflare documents broad `Workers Scripts Edit` authority for version and deployment writes, not an upload-only permission. Treat the CI principal as technically capable of production deployment. Workflow separation alone is not a security boundary: promotion requires a separately protected approval/broker boundary that CI cannot invoke.
 7. **Smoke + contract checklist** — Probe only `GET /api/v1/health` and the SPA index/referenced assets with synthetic data. Add producer/consumer contract evidence for shared wire changes and verify the SPA’s baked API origin.
 8. **Owners + drill** — Name deployable/contract owners and rota; execute one rollback drill including blocked-rollback and partial-pair decisions.
 9. **Docs pointers** — Link AGENTS/README or deploy notes to this design and operating model.
@@ -411,7 +411,7 @@ Ordered conceptual work packages only—this document does not provide YAML, Wra
 
 - Binding decisions: [cd-operating-model.md](./cd-operating-model.md)
 - Architecture assessment: [continuous-deployment-workers.md](./continuous-deployment-workers.md)
-- Implementation evidence and research procedure: [cd-stage1-2-implementation-evidence.md](./cd-stage1-2-implementation-evidence.md)
+- Implementation evidence, diagrams, schemas, and Cursor conversation starters: [cd-stage1-2-implementation-evidence.md](./cd-stage1-2-implementation-evidence.md)
 - [Versions & deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
 - [Deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)
 - [Preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)

--- a/docs/cd-stage1-2-design.md
+++ b/docs/cd-stage1-2-design.md
@@ -2,25 +2,26 @@
 
 > Implementable design for continuous **delivery of versions** (Stage 1) and **progressive exposure** (Stage 2) for `worker-api` and `front-app`. Bound by [cd-operating-model.md](./cd-operating-model.md). Architecture rationale: [continuous-deployment-workers.md](./continuous-deployment-workers.md).
 
-**Audience:** On-call engineers during a bad deploy; Chat C implementers of Stage 1 CI/upload/promote.
+**Audience:** On-call engineers during a bad deploy and implementers of Stage 1 CI/upload/promote.
 
 **Hard distinction:** Cloudflare **Worker version / gradual deployment / version affinity / rollback** control which **binary** serves traffic. **Flagship** controls which **behavior** runs inside already-deployed code. Never conflate them.
 
-**Privileged data (standing):** Client/matter identifiers must not appear in log lines, trace attributes, error bodies, cache keys, URL paths/query strings, or Flagship targeting contexts. Correlate with opaque request IDs only.
+**Privileged data (standing):** Client/matter identifiers and privileged content must not appear in logs, trace attributes, metric dimensions, error bodies, cache/affinity keys, URL paths/query strings, smoke data, screenshots, or Flagship contexts. Correlate with opaque request IDs only.
 
 ---
 
-## Assumptions (locked)
+## Assumptions and current blockers
 
 | Topic | Decision |
 |-------|----------|
-| Promote authority | Deployable **owner or on-call delegate** (single human). **No dual-control** for Stage 1–2 on this thin surface. |
+| Promote authority | Deployable **owner or on-call delegate** (single human). The role is decided; named people/rota and contract owners are not yet recorded and block Stage 1 exit. |
 | Staging | **Real habit, not a hard CI gate.** Prefer staging or versioned preview smoke before production promote; hotfixes may skip staging with a documented reason. |
-| Upload trigger | Merge/`push` to **`main`** after verify CI green → **affected-only** version upload. PRs stay verify-only. |
+| Upload trigger | Target state: merge/`push` to **`main`** after verify CI green → **affected-only** version upload. PRs stay verify-only. The repository has no upload job today. |
 | Orchestration | **GitHub Actions + Turbo `--affected`**. Workers Builds is not the monorepo brain. |
-| Production env | Wrangler **`production`** env for uploaded/promoted versions. |
-| Preview URLs | Stage 1 requires them enabled for smoke (`front-app` today has `preview_urls: false`). |
-| Shared contracts | When Turbo marks both apps affected (typical `@repo/dtos-common` / enums change), upload **both** and promote as **one window**. |
+| Production env | Wrangler **`production`** env. The actual Worker resources are currently `worker-api-production` and `front-app-production`; records and commands use the actual name. |
+| Preview URLs | `front-app` explicitly disables them today; `worker-api` does not pin the setting. If enabled for Stage 1, previews must be Access-protected because enabled URLs are public and have no Workers Logs, `wrangler tail`, or Logpush. |
+| Shared contracts | When Turbo marks both apps affected, upload both from the same commit. Promotions are ordered per Worker and independently verified; Cloudflare provides no multi-Worker transaction. |
+| Stage 2 SPA gate | Blocked today: `front-app` is assets-only on `workers.dev`, where Transform Rules are unavailable. A zone route/custom domain plus first-request affinity must exist before a SPA split. |
 
 ---
 
@@ -28,15 +29,15 @@
 
 | Actor | Stage 1 | Stage 2 |
 |-------|---------|---------|
-| **CI (GitHub Actions + Turbo)** | Verify; build affected; `versions upload`; publish version IDs + preview URLs. Never moves production traffic. | Same upload path. Does **not** advance percentage ramps. |
-| **Human (owner / on-call)** | Smoke; classify change; promote to 100% (or abort); rollback. | Start/hold/advance/rollback gradual splits; watch version-diff and asset 404s; Flagship kill-switch when applicable. |
-| **Cloudflare platform** | Immutable versions; preview URLs; deployments; rollback to last 100 versions. | Gradual % splits; version affinity; version overrides; per-version metrics; Flagship evaluation (once wired). |
+| **CI (GitHub Actions + Turbo)** | Verify; compute affected range; build; upload; publish commit, actual Worker name, version ID, and protected preview URL when used. Never creates a traffic-serving deployment. | Same upload path. Does **not** advance percentages. |
+| **Human (owner / on-call)** | Recheck active deployment; smoke; classify; promote to 100% or abort; verify; rollback. | Start/hold/advance/complete/rollback a split; continuously watch required signals; use Flagship only when wired and proven. |
+| **Cloudflare platform** | Immutable versions and per-Worker deployments; public preview URLs when enabled; rollback among the 100 most recently published versions, subject to constraints. | At most two versions in one deployment; per-request percentage routing; affinity and overrides; version attribution through supported telemetry. |
 
 ---
 
 ## A. Stage 1 — Upload ≠ promote
 
-Goal: every eligible merge produces an immutable Worker **version** with **0% automatic traffic**. A human decides when that version serves production.
+Goal: every eligible merge produces an immutable Worker **version outside the active deployment**. A human decides whether to create a production deployment. “Uploaded” does not mean “deployed at 0%.”
 
 ### Stage 1 flow
 
@@ -46,11 +47,15 @@ flowchart LR
   Verify --> Affected[Turbo_affected]
   Affected --> Upload[versions_upload]
   Upload --> Record[Record_version_IDs]
-  Record --> Smoke[Smoke_preview_URL]
-  Smoke --> Human{Human_promote}
+  Record --> Smoke{Smoke_method}
+  Smoke -->|protected_preview| Preview[Smoke_preview_URL]
+  Smoke -->|production_shaped| DeployZero[Deploy_new_0pct]
+  DeployZero --> Override[Smoke_with_override]
+  Preview --> Human{Human_promote}
+  Override --> Human
   Human -->|yes| Deploy100[versions_deploy_100pct]
   Human -->|abort| Idle[Leave_version_idle]
-  Deploy100 --> Watch[Watch_errors_latency]
+  Deploy100 --> VerifyActive[Verify_active_version_and_signals]
 ```
 
 ### Trigger
@@ -58,54 +63,79 @@ flowchart LR
 | Event | Action |
 |-------|--------|
 | `pull_request` | Verify only (existing CI). No production upload. |
-| `push` / merge to `main` (after verify green) | Affected-only **version upload** for deployables that would rebuild for `build` / `deploy`. |
+| `push` / merge to `main` (after verify green) | Affected-only **version upload** for deployables that would rebuild for `build`. |
 | Manual / hotfix | Same upload path; promote may skip staging with documented reason (operating-model emergency class). |
 
 **Deployables today:** `worker-api`, `front-app`. Workspace packages (`@repo/dtos-common`, `@repo/enums-common`) are **inputs**, not uploadable artifacts—they ship inside consumer versions.
 
-**Affected honesty:** If Turbo would rebuild the app, upload a new version. If not, do not upload a decorative version. Never “always deploy all.”
+**Affected honesty:** Record the base/head range. If Turbo cannot resolve it or widens to everything, stop or explicitly upload both; never silently narrow. If an app would rebuild, upload a new version. If not, do not upload a decorative version.
+
+**Bootstrap exception:** this recurring flow assumes the Worker has been published before. Cloudflare requires the first upload of a new Worker to use `wrangler deploy`; `versions upload` fails for a first publish.
 
 ### Artifact: what a “version” is
 
 | App | Immutable version contains | Notes |
 |-----|----------------------------|-------|
-| `worker-api` | Worker script + Wrangler bindings/config/compat for that env | Hono gateway; no static asset tree as primary payload. |
-| `front-app` | Worker + **Vite build output** as Workers static assets (`assets.directory`) | Content-hashed JS/CSS filenames; SPA `not_found_handling`. |
+| `worker-api` | Worker script + version-specific bindings and compatibility settings for production | Hono gateway; no static asset tree as primary payload. |
+| `front-app` | **Production-environment Vite output** as Workers static assets plus version-specific settings | Content-hashed JS/CSS filenames; `VITE_API_BASE_URL` is frozen into the build. |
 
-A version is **not** an npm package version. Last **100** versions remain eligible for deploy/rollback (platform limit).
+A version is **not** an npm package version. Deployments can select only the 100 most recent uploaded versions; rollback can select the 100 most recently published versions.
 
-Binding *configuration* is versioned with the Worker. **Data** in future KV/R2/DO/D1/Queues is not. Rollback of code does not rewind storage.
+Routes, domains, and cron triggers are not applied by `versions upload`. Connected resource state, secret contents, and future KV/R2/DO/D1/Queue data are not rewound by rollback. A rollback may be blocked if a referenced resource no longer exists or a Durable Object lifecycle change intervened.
 
 ### Smoke strategy
 
 | Method | When | Mechanism |
 |--------|------|-----------|
-| **Primary** | After every upload | **Versioned preview URL** (`<version-prefix>-<worker>.<subdomain>.workers.dev`). Requires preview URLs enabled. |
-| **Optional production-shaped** | Before a cautious promote | Put new version in the **active deployment at 0%**, then hit production hostname with `Cloudflare-Workers-Version-Overrides` (override applies only if the version is in the current deployment). |
+| **Protected preview** | After upload, when Access is configured | Versioned preview URL. It tests the version but not zone-level performance/security controls, and preview invocations have no Workers Logs, `wrangler tail`, or Logpush. |
+| **Trusted production-shaped smoke** | When zone behavior must be exercised | Put the new version in the active deployment at 0%, then use `Cloudflare-Workers-Version-Overrides` through an access-controlled smoke path. |
 | Staging env | Habit for non-trivial / non-hotfix | Promote or upload against Wrangler `staging` before production promote—useful, not a CI hard gate. |
 
-**Smoke proves:** process boots; `worker-api` health/ready succeeds; `front-app` shell (index HTML + critical assets) loads; no obvious 5xx on the smoke paths.
+Preview URLs are not isolated staging: a preview of a production-environment version uses that version’s production bindings/settings and is publicly reachable unless Access protects it. Never send real client/matter traffic or credentials merely because the hostname says “preview.”
 
-**Smoke cannot prove:** real traffic mix; SPA↔API skew under a gradual split; product correctness on privileged paths (use opaque/synthetic IDs only—never real matter/client identifiers in smoke URLs, logs, or flag context).
+Version overrides are not an authorization mechanism. They apply only while the version is one of the active deployment’s two versions; an invalid or not-yet-propagated override falls back to normal percentage routing. The trusted zone boundary must block or remove `Cloudflare-Workers-Version-Overrides` from untrusted requests while a 0% version is active. The smoke runner must verify the served version before accepting any response, wait/retry the documented short propagation window, and abort rather than test an unverified version.
+
+**Smoke proves:** the selected version responds; `GET /api/v1/health` succeeds for `worker-api`; `front-app` index HTML and every referenced critical JS/CSS asset load. For paired changes, confirm the SPA artifact’s baked `VITE_API_BASE_URL` targets the intended API resource and test against the compatible API version.
+
+**Smoke cannot prove:** real traffic mix, full zone behavior from preview, end-to-end telemetry, SPA↔API skew under a split, or product correctness on privileged paths. Use synthetic data and rollout-only opaque IDs; never put client/matter identifiers in URLs, logs, traces, cache/affinity keys, errors, or Flagship context.
+
+### Pre-promote record
+
+Before any deployment mutation, the operator records:
+
+1. Commit SHA, change class, affected base/head, actual production Worker name, new version ID, and previous active deployment/version.
+2. For a shared-wire change, both uploaded version IDs and the contract evidence. A missing pair blocks all traffic movement.
+3. Smoke method and result, including the served version. Preview success alone does not prove production zone controls.
+4. The exact next state: Stage 1 new 100%; Stage 2 old/new percentages. Re-read the active deployment immediately before applying it and abort if another operator or process changed it.
 
 ### Promote authority
 
 - **Who:** deployable owner or on-call delegate.
-- **How:** Cloudflare dashboard “Promote” or Wrangler `versions deploy` → **100%** in Stage 1.
+- **Concurrency:** one named operator and one in-flight deployment change per Worker. A changed active deployment invalidates the plan and requires re-evaluation.
+- **How:** Cloudflare dashboard “Promote” or Wrangler `versions deploy` → **100%** in Stage 1, using the actual `<name>-production` resource.
 - **Dual-control:** not required for Stage 1–2.
 - **Staging:** preferred before production for non-trivial changes; optional for documented hotfixes.
+- **Completion:** not complete until the active deployment reports the expected version and production probes/signals are healthy. Cloudflare documents global availability of override changes within up to a couple of seconds, not a zero-time cross-Worker cutover.
 
-Change-class gates from the operating model still apply: binding topology / secrets shape / future storage migrations are not “routine” promotes.
+Change-class gates from the operating model still apply: bindings, compatibility settings, triggers, connected resources, secret contents, and future storage migrations are not “routine” promotes.
+
+For a coordinated HTTP change, Cloudflare cannot promote both Workers atomically:
+
+- **Additive support:** deploy `worker-api` support to 100%, verify compatibility with the old SPA, then deploy/ramp `front-app`.
+- **Removal:** deploy the SPA that no longer uses the shape, retain the old API through the measured open-client retirement window, then remove the API shape in a later compatible change.
+- **Independent change:** mutate only the affected Worker. Do not co-ramp both merely because they share a release window.
 
 ### Failure modes
 
 | Failure | Effect | Action |
 |---------|--------|--------|
 | CI verify red | No upload | Fix on branch; do not promote anything from that SHA. |
-| Upload fail (one or both apps) | No new eligible version | Fix credentials/config/build; re-run upload. Do not promote a half-pair when both were required. |
-| Smoke fail | Version exists at 0% traffic | Do not promote. Leave idle or roll forward with a fixed upload. |
+| Upload fail | Zero or one inactive versions may exist | Do not promote a required pair. Fix the failed upload, then verify both versions have the same commit/build provenance; do not re-upload the successful immutable version without cause. |
+| Smoke fail before 0% deployment | Version exists outside active deployment | Do not promote. Leave it idle and upload a fixed version. |
+| Smoke fail after 0% deployment | New version is active at 0%; normal traffic remains on old 100%, but overrides can select new | Restore the prior single-version deployment or leave 0% only for a bounded investigation; restrict the override path. |
 | Promote abort (human stops) | Prior version remains 100% | Record why; idle new version is fine. |
-| Partial multi-app success (e.g. `worker-api` uploaded, `front-app` failed) when both required | Incompatible promote window risk | **Promote neither.** Fix and re-upload both; then one promote window. |
+| Partial multi-app promote | One Worker changed; no automatic undo | Stop further changes. If the state is contract-compatible, hold and repair the missing step; otherwise use the compatibility matrix to roll back the changed side or complete the safe counterpart. Never assume joint rollback. |
+| Wrong version or concurrent change detected | Planned previous/new pair is no longer active | Hold. Re-read deployment history and either restore the known-good version or build a new plan from current state. |
 
 ### Rollback in Stage 1
 
@@ -117,16 +147,17 @@ Change-class gates from the operating model still apply: binding topology / secr
 | Account-level DNS / routes / unbound config / secret **contents** wrong outside the version | **No** — fix that surface; Worker rollback alone may not undo it. |
 | Binding deleted/modified so platform refuses rollback | **No** — platform blocks unsafe rollbacks (e.g. missing KV/R2/queue binding targets; DO class lifecycle gaps). |
 
-Rollback creates a new deployment selecting a prior version. It does not rewind data.
+Rollback creates a new single-version deployment at 100%, replacing both sides of a split. Before rollback, verify the target is among the 100 most recently published versions, its resource assumptions still hold, and it remains compatible with the other live app. After rollback, verify the active deployment and production probes; the command returning successfully is not incident closure. It does not rewind data or external control-plane state.
 
 ### Definition of Done — Stage 1
 
 - [ ] CI remains the merge gate (boundaries, lint, format, affected typecheck/build).
 - [ ] On `main`, affected deployables get **`versions upload` without automatic 100% traffic**; practiced until boring on a non-critical path.
-- [ ] Preview URLs enabled; smoke habit uses preview URL (and optionally 0% + override).
+- [ ] Preview smoke is Access-protected, or a trusted 0%-override path verifies the served version. Public production-bound previews are not accepted.
 - [ ] Staging or preview habit used before production promote for non-hotfix changes.
 - [ ] **Rollback drill** completed; time-to-mitigate measured; “what rollback does not undo” understood.
 - [ ] Named owners for `worker-api`, `front-app`, and shared contracts (`@repo/dtos-common` / `@repo/enums-common`).
+- [ ] Shared HTTP changes have contract-test or equivalent producer/consumer evidence; types alone are insufficient.
 - [ ] Package scripts / CI conceptually split **upload** vs **promote**; `wrangler deploy` (upload+100%) is not the Stage 1 default path for `main`.
 
 Exit criteria align with operating-model **Stage 0 → 1**.
@@ -135,19 +166,30 @@ Exit criteria align with operating-model **Stage 0 → 1**.
 
 ## B. Stage 2 — Progressive exposure
 
-Goal: production promotes can **split traffic** between two versions; humans advance using version-diff signals. Upload path stays Stage 1.
+Goal: a human can split one Worker’s traffic between exactly two versions and advance only with verified affinity and version-aware signals. The Stage 1 upload path is unchanged. There is no atomic cross-Worker ramp.
+
+### Entry gate
+
+Do not create a non-zero production split until all are true:
+
+- Stage 1 is complete and a rollback drill has passed.
+- The actual old/new version IDs and prior active deployment are recorded.
+- Runtime failures, application HTTP 5xx, measured performance, and `front-app` asset 404s are visible with sufficient version attribution.
+- End-to-end request correlation uses opaque IDs only.
+- For `front-app`, a zone route/custom domain and an affinity key present on the first HTML request and all assets have been tested. The current assets-only `workers.dev` posture does not pass this gate.
+- The operator declares the percentage, minimum bake time, minimum useful sample, and rollback threshold. Low traffic or delayed metrics means hold, not advance.
 
 ### Stage 2 flow
 
 ```mermaid
 flowchart LR
   Uploaded[Uploaded_versions] --> StartSplit[Human_start_pct_split]
-  StartSplit --> Affinity[front_app_version_affinity]
-  Affinity --> WatchSignals[Watch_version_diff_and_404s]
-  WatchSignals --> Decide{Pause_hold_advance_rollback}
+  StartSplit --> WatchSignals[Watch_version_runtime_http_asset_signals]
+  WatchSignals --> Decide{Hold_advance_complete_rollback}
   Decide -->|advance| NextPct[Raise_new_version_pct]
+  Decide -->|hold| WatchSignals
+  Decide -->|complete| New100[New_version_100pct]
   Decide -->|rollback| Prior100[Prior_version_100pct]
-  Decide -->|feature_fault| FlagOff[Flagship_kill_switch]
   NextPct --> WatchSignals
 ```
 
@@ -155,16 +197,20 @@ flowchart LR
 
 | Deployable | Ramp | Affinity |
 |------------|------|----------|
-| `worker-api` | Short percentage ladder for non-trivial changes (e.g. 10 → 50 → 100). Immediate 100% only for trivial/hotfix when delay risk exceeds cutover risk (document the skip). | Nice-to-have for sticky debugging; **not mandatory** for pure JSON API responses. |
-| `front-app` | Same ladder bias for non-trivial UI/asset changes. | **Mandatory** whenever traffic is split. |
+| `worker-api` | Select steps from traffic volume and risk; there is no universal 10→50→100 ladder. Immediate 100% is Stage 1 behavior and requires a recorded reason when Stage 2 would otherwise apply. | Optional for request-independent APIs; it does not solve SPA↔API generation skew. |
+| `front-app` | Select steps only after first-request affinity and asset-404 telemetry pass the entry gate. | **Mandatory** whenever traffic is split. |
 
-Regional geography is not a primary lever.
+Percentages are independent per-request probabilities. Without affinity, repeated requests can reach different versions; percentages do not guarantee exact sample sizes, cohort membership, geography, or ordering. One active deployment can contain only the old and new version. Finish or roll back the current split before introducing a third version.
+
+Do not ramp both apps concurrently by default. Complete and verify additive API support before exposing the dependent SPA. Concurrent independent ramps are allowed only when the operator records that neither change shares a wire or diagnostic dependency.
 
 ### Version affinity for `front-app` (mandatory on splits)
 
 Without affinity, each request is independently routed by percentage. Vite content-hashed assets then fail as: HTML from version A references `index-a1b2c3d4.js`, browser fetch lands on version B → **404** → broken page.
 
-**Requirement:** set `Cloudflare-Workers-Version-Key` on inbound requests to `front-app` (preferred: zone **Transform Rule** from a stable session/cookie value that is **not** a client/matter identifier). Platform hashes the key; you do not pick which version a key maps to. As percentages rise, keys already on the new version stay there.
+**Requirement:** overwrite `Cloudflare-Workers-Version-Key` at a trusted zone boundary using a dedicated random rollout cookie/value. Do not reuse an auth/session secret or any user/client/matter identifier. The key contributes to infrastructure cache partitioning. Cloudflare hashes it; operators do not choose the mapped version. As percentages rise, keys already on the new version stay there.
+
+The key must exist before the first HTML request. Cloudflare documents that a cookie created by the first response cannot affect that first random assignment; treating response-created affinity as complete protection overclaims the platform. Transform Rules require a route on a controlled zone and are unavailable for `workers.dev`.
 
 Affinity pins **within** `front-app` only. It does **not** lock `front-app` and `worker-api` to the same generation.
 
@@ -173,30 +219,32 @@ Affinity pins **within** `front-app` only. It does **not** lock `front-app` and 
 | Control | Rule |
 |---------|------|
 | Compatibility window | HTTP DTOs in `@repo/dtos-common`: expand/contract; **N and N+1 must coexist** during independent ramps. |
-| Promote order (additive) | Upload/promote **API support first**, then SPA that depends on it. |
-| Promote order (removal) | Migrate/remove SPA usage first, then remove API shape. |
+| Promote order (additive) | Deploy **API support to 100% and verify the old SPA**, then ramp the dependent SPA. |
+| Promote order (removal) | Ramp SPA removal to 100%, retain API compatibility through a measured open-client retirement window, then remove API shape in a later change. |
 | Same-PR discipline | Additive wire changes that need consumer updates land in the **same PR**; still yield multiple uploadable versions. |
 | Do not ship together | Breaking removals with consumers still live; binding topology with “routine” UI; anything labeled migration as a silent co-ramp. |
+| Rollback | Check compatibility with the other live app before one-sided rollback; Cloudflare provides no joint rollback. |
 
-### Signals — pause / hold / advance / roll back
+### Signals — hold / advance / complete / roll back
 
 Tied to the operating-model observability bar (also Stage 2 practice for **manual** gradual promotes):
 
 | Signal | Use |
 |--------|-----|
-| Version-diff **error / exception** rate | New version worse → **pause** or **rollback**. |
-| Version-diff **latency** (at least p95) | Sustained regression → **hold**; do not advance. |
-| `front-app` **asset 404** rate | Classic affinity/skew → **pause**; verify affinity; often **rollback** the SPA split. |
-| Opaque **request ID** correlation `front-app` → `worker-api` | Debug without privileged identifiers. |
+| Version-attributed invocation failures / exceptions | New version worse → **hold** or **rollback**. |
+| Application HTTP 5xx by version | Required because a successful invocation can still return an application error. |
+| Version-attributed wall/CPU time or instrumented response latency | Hold on sustained regression; name the metric accurately. Cloudflare wall time is not final-byte latency. |
+| `front-app` asset 404 by version | Affinity/skew signal → hold; verify first-request affinity; usually roll back the SPA split. |
+| Opaque request ID correlation `front-app` → `worker-api` | Debug without privileged identifiers; currently an unmet repository prerequisite. |
 
-**Targets:** time-to-detect ≤ **5 minutes** after a ramp step; time-to-mitigate ≤ **15 minutes**.
+**Internal objectives, not Cloudflare guarantees:** time-to-detect ≤ **5 minutes** after a ramp step; time-to-mitigate ≤ **15 minutes**. If current metrics lag or the sample is insufficient to evaluate the objective, hold.
 
 | Decision | When |
 |----------|------|
-| **Advance** | Version-diff healthy for the bake window; no asset-404 spike; no known contract alarm. |
-| **Hold** | Ambiguous signal; waiting for bake; coordinated second app not ready. |
-| **Pause** (keep current split) | Investigating; do not raise %. |
-| **Rollback** (prior version 100%) | Confirmed binary regression or SPA 404 skew; see runbooks. |
+| **Advance** | Minimum bake and sample met; all required new-vs-old signals healthy; no contract alarm. Create a replacement deployment with a higher new-version percentage. |
+| **Hold** | Make no control-plane change. Use for ambiguous/delayed signals, insufficient sample, or a counterpart not ready. “Pause” is not a separate platform action. |
+| **Complete** | Create a single-version deployment at new 100% only after the final gate passes. |
+| **Rollback** | Create a single-version deployment selecting the known-good prior version at 100%; verify active state and probes. |
 
 CI green never authorizes skipping these signals on a gradual path.
 
@@ -207,11 +255,14 @@ CI green never authorizes skipping these signals on a gradual path.
 | Workers gradual deployment | Which **Worker version** serves the request | Version affinity header | Blast radius of **code** just shipped |
 | Flagship % / targeting | Which **behavior/config** runs inside deployed code | Consistent hash on a stable, **non-privileged** attribute | Feature exposure & **kill-switch** without redeploy |
 
-- Evaluate on **`worker-api` Flagship binding** (edge-local; no app-managed token). `front-app` learns via API/bootstrap payload.
+- Flagship is not wired and is not a Stage 2 prerequisite or guaranteed mitigation.
+- If adopted, evaluate on **`worker-api` Flagship binding** (edge-local; no app-managed token). `front-app` learns via API/bootstrap payload.
 - **Do not** ship Cloudflare API tokens in a browser OpenFeature client provider (docs: not recommended for public apps).
-- Every evaluation supplies a **safe default**; failure → safe-off.
-- Flag targeting context: no matter/client identifiers.
+- Typed methods use a safe call-site fallback for known failures; unexpected runtime failures can throw and must be caught into the same safe behavior. A disabled flag serves its configured default variant.
+- Flag targeting and rollout context uses a dedicated opaque rollout key and only necessary non-privileged attributes—never user/client/matter identifiers or content.
+- Flag changes can take up to 30 seconds to propagate globally. Confirm the safe variant before declaring mitigation; if severity cannot tolerate that window, use the binary rollback path.
 - Flagship disable ≠ schema safety for future queues/DO/DB.
+- Do not ramp the Worker percentage and Flagship percentage for the same risky path simultaneously.
 
 Until Flagship is wired, incomplete features stay off by code path or do not merge—do not invent a second SPA flag SaaS.
 
@@ -219,7 +270,7 @@ Until Flagship is wired, incomplete features stay off by code path or do not mer
 
 | Remains manual in Stage 2 | May automate later (Stage 3+) — do not design here |
 |---------------------------|-----------------------------------------------------|
-| Start / advance / pause percentage | Metric-gated auto-ramp policies |
+| Start / advance / hold / complete percentage | Metric-gated auto-ramp policies |
 | Rollback / Flagship kill | Auto-pause robots |
 | Change-class “is this routine?” judgment | Policy engine for routine vs migration |
 | Coordinated multi-app promote windows | Richer multi-Worker order playbooks |
@@ -228,39 +279,85 @@ Until Flagship is wired, incomplete features stay off by code path or do not mer
 
 ## C. Runbooks
 
+### Common first actions
+
+1. Name one incident operator; stop other deploy/promote jobs and do not create another deployment while state is being reconstructed.
+2. Record the actual Worker name, active deployment, both version IDs/percentages, last known-good version, commit SHA, change class, and whether the other app changed.
+3. Hold: make no percentage change until the relevant runbook identifies a safe next state.
+4. Use only opaque request IDs and synthetic probes. Do not put client/matter data in URLs, logs, traces, metric dimensions, cache/affinity keys, errors, screenshots, or Flagship context.
+
 ### Bad error-rate after promote
 
-1. Confirm version-diff (new vs old), not only global spike.
-2. If new feature/path only → **Flagship disable** (if wired); else disable by config/code forward-fix.
-3. If regressed correct old behavior, no storage/schema change → **Worker version rollback** to prior 100%.
-4. If irreversible migration suspected → **forward-fix**; do not blind-rollback.
-5. Mitigate within 15 minutes; leave a short note (what signal, which lever).
+1. Compare new vs old **application HTTP 5xx** and invocation failures; do not infer application health from invocation outcome alone.
+2. If both versions degraded equally, follow the non-deploy incident path below.
+3. If a Flagship-controlled path alone regressed and Flagship is wired, disable it and observe for up to the documented 30-second propagation window. Confirm the safe variant; do not assume save equals global effect.
+4. Otherwise, if old code is compatible with current app/data state, roll back the Worker to prior 100%.
+5. If rollback is unsafe or blocked, upload and promote a versioned forward fix through the same controls. Never patch production outside the version model.
 
 ### Asset 404 spike during `front-app` ramp
 
 1. Treat as **affinity or asset skew** until proven otherwise.
-2. **Pause** further % advances immediately.
-3. Verify `Cloudflare-Workers-Version-Key` is present and stable for browsers fetching HTML and hashed assets.
-4. If affinity missing/broken or 404s continue → **rollback** `front-app` to prior version 100%.
+2. **Hold** immediately.
+3. Verify the trusted boundary overwrites `Cloudflare-Workers-Version-Key` and that the dedicated rollout key was present on the first HTML request and every asset request.
+4. If affinity is missing/broken or 404s continue, roll back `front-app` to prior version 100% and verify all index-referenced assets.
 5. Do not “fix” by redeploying API first—this is an SPA binary-split symptom.
 
 ### Suspected contract skew (SPA ↔ API)
 
-1. Pause promotes on **both** apps.
-2. Compare which versions are live (%); check whether an additive/removal landed without expand window.
-3. Prefer aligning versions (promote the compatible pair or roll the incompatible side back).
-4. Flag off risky paths if Flagship covers them.
-5. Debugging: opaque request IDs only—no matter/client IDs in logs or traces.
+1. Hold both apps and record the actual versions/percentages plus the SPA’s baked API origin.
+2. Check whether an additive/removal landed without an expand window and whether already-open SPA clients still use the old shape.
+3. For additive changes, prefer completing compatible API support before any SPA advance. For removals, restore API compatibility; do not assume 100% new SPA traffic retired open tabs.
+4. If one app was promoted accidentally, choose the next state from the compatibility matrix—repair forward when current state is safe, otherwise roll back the changed side.
+5. Flag off risky paths only if Flagship covers them and the safe variant is verified.
+6. Debugging: opaque request IDs only—no matter/client IDs in logs or traces.
+
+### Latency or resource regression without errors
+
+1. Confirm what the chart measures. Worker wall time includes I/O and `waitUntil`; CPU time is not response latency; request duration has product/config limitations.
+2. Compare the same metric and sample window between versions. If the sample is too small or recent data is delayed, hold.
+3. If only the new version regresses beyond the declared threshold, roll back. If both versions regress, investigate the platform/upstream before changing deployment.
+
+### Global spike with no version differential
+
+1. Hold the ramp; do not blame the new version solely because a deployment is in progress.
+2. Check Cloudflare status, upstream dependencies, traffic/security events, and both app resources using non-privileged aggregate signals.
+3. Roll back only if evidence links the new binary to the failure. Otherwise preserve the split while mitigating the actual dependency, or return to the last known-good single version if reducing variables is worth the cutover risk.
+
+### Wrong version, concurrent change, or stale operator state
+
+1. Stop all deployment actors and re-read the current active deployment/history.
+2. If the unexpected version is harmful and the prior version remains compatible, roll back to prior 100%.
+3. If it is healthy, do not overwrite it reflexively; rebuild the plan from current state and re-run smoke/compatibility checks.
+4. Record the concurrency failure. One operator and one in-flight deployment per Worker remain mandatory.
+
+### Rollback blocked or ineffective
+
+1. Capture the platform error without secret values or privileged request data.
+2. Check for missing/modified bindings, deleted R2/KV/Queue targets, Durable Object lifecycle changes, external routes/DNS/secrets, or incompatible data.
+3. Restore the external resource only through its own approved change control when safe; otherwise upload a compatible forward-fix version.
+4. If the command succeeded but probes remain bad, verify the active deployment/version and whether the fault lives outside versioned state.
+5. Escalate; repeated rollback attempts do not repair external state.
+
+### Partial multi-app promote
+
+1. Hold both apps and record which independent deployment changed.
+2. If the new state is backward compatible, keep the safe side stable and complete the missing ordered step after smoke.
+3. If incompatible, restore the last compatible pair using additive-API-first/removal-API-last ordering. There is no atomic pair rollback.
+4. Do not upload replacement versions solely to make IDs look paired; provenance and compatibility, not adjacency, matter.
+
+### Incident closure
+
+Mitigation is complete only when the expected deployment is active, production probes and relevant version/application signals are healthy, and any Flagship safe variant has propagated. Record UTC times, versions, percentages, decision/lever, TTD/TTM, residual external state, and follow-up owner—without privileged identifiers.
 
 ### Mitigation precedence (decision table)
 
 | Situation | Prefer first | Then |
 |-----------|--------------|------|
-| New feature/path causing errors; new version otherwise healthy | **Flagship kill-switch / disable** | Version rollback if flag insufficient |
+| New feature/path causing errors; new version otherwise healthy | **Flagship kill-switch / disable**, only if wired; verify propagation | Version rollback if flag absent, delayed, or insufficient |
 | Regressed correct old behavior; no schema/storage change | **Worker version rollback** | Forward-fix if rollback blocked |
 | Bad / irreversible storage or message schema migration | **Forward-fix** (or product restore) | Not blind Worker rollback |
-| Partial multi-app incompatible ramp | Pause; align versions; flag off | Rollback the offending side |
-| SPA asset 404s during split | Pause; fix/verify affinity; **SPA version rollback** | Re-ramp only with affinity proven |
+| Partial multi-app incompatible ramp | Hold; align versions in compatibility order; flag off if proven | Rollback the offending side |
+| SPA asset 404s during split | Hold; verify first-request affinity; **SPA version rollback** | Re-ramp only with affinity proven |
 | CI/upload/smoke failure | Do not promote | Re-upload after fix |
 
 ---
@@ -275,21 +372,23 @@ Until Flagship is wired, incomplete features stay off by code path or do not mer
 - Full Stage 3 auto-ramp / change-class automation design
 - Multi-Worker service-binding RPC order playbooks as the default path
 - Scheduled release trains; regional rollouts as primary CD lever
-- Always-deploy-all (rejected by operating model)
+- Routine always-deploy-all (explicit widening on uncertain/shared impact remains allowed)
 
 ---
 
 ## E. Implementation handoff — Stage 1 only
 
-Ordered work packages for Chat C. Conceptual areas only—no YAML or app feature code in this doc.
+Ordered conceptual work packages only—this document does not provide YAML, Wrangler configuration, or application code:
 
-1. **Preview URLs** — Enable for `worker-api` and `front-app`; confirm access posture for smoke.
-2. **Scripts split** — Per-app conceptual paths: **upload** (`versions upload` + production env) vs **promote** (`versions deploy`). Stop treating `wrangler deploy` (upload+immediate 100%) as the Stage 1 default for `main`.
-3. **CI upload job** — On `main` after verify: Turbo `--affected` → build → upload → publish version IDs and preview URLs (artifacts / job summary). **No auto-promote.**
-4. **Secrets** — `CLOUDFLARE_API_TOKEN` + account id for upload (least privilege); never commit; no privileged payload in logs. Promote via human-gated `workflow_dispatch` and/or dashboard.
-5. **Smoke checklist** — Minimal probes: `worker-api` health/ready; `front-app` index/shell. Synthetic IDs only.
-6. **Owners + drill** — Named owners/rota; execute and record one rollback drill (TTM).
-7. **Docs pointers** — Link AGENTS/README (or deploy notes) to this design + operating model.
+1. **Bootstrap inventory** — Confirm both `<name>-production` Workers already exist. A first publish uses the bootstrap deploy path; only recurring releases use `versions upload`.
+2. **Protected smoke path** — Keep preview URLs disabled unless Cloudflare Access protects them. When enabled, account for their missing logs and zone controls. Define the trusted 0%-override alternative and served-version verification.
+3. **Scripts split** — Per-app conceptual paths: **upload** (`versions upload` for the production environment) vs **promote** (`versions deploy`). Stop treating `wrangler deploy` (upload+immediate 100%) as the recurring Stage 1 `main` path.
+4. **Build provenance** — Build `front-app` for the production Cloudflare/Vite environment, record `VITE_API_BASE_URL`, commit SHA, affected base/head, actual Worker name, and returned version ID.
+5. **CI upload job** — On `main` after verify: compute affected build graph → build → upload → publish non-secret release evidence. **No deployment mutation.**
+6. **Credential boundary** — Use a least-privilege Cloudflare token and account ID for upload; never commit or log them. Do not claim token-level “upload-only” isolation unless the Cloudflare permission is verified; the workflow must still contain no promote step, and human deployment authority uses a separately controlled principal.
+7. **Smoke + contract checklist** — Probe only `GET /api/v1/health` and the SPA index/referenced assets with synthetic data. Add producer/consumer contract evidence for shared wire changes and verify the SPA’s baked API origin.
+8. **Owners + drill** — Name deployable/contract owners and rota; execute one rollback drill including blocked-rollback and partial-pair decisions.
+9. **Docs pointers** — Link AGENTS/README or deploy notes to this design and operating model.
 
 ### Do not build in Stage 1
 
@@ -297,7 +396,7 @@ Ordered work packages for Chat C. Conceptual areas only—no YAML or app feature
 - Version affinity Transform Rules (Stage 2)
 - Flagship wiring as a required production gate
 - Workers Builds replacing GitHub Actions + Turbo
-- Always-deploy-all
+- Routine always-deploy-all
 - Dual-control approval gates
 - Queue/DO/storage migration playbooks
 - Browser Flagship tokens
@@ -316,7 +415,12 @@ Ordered work packages for Chat C. Conceptual areas only—no YAML or app feature
 - [Gradual deployments](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/)
 - [Version affinity](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/)
 - [Rollbacks](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/)
+- [Wrangler environments](https://developers.cloudflare.com/workers/wrangler/environments/)
+- [Workers metrics and analytics](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/)
+- [Workers cache keys](https://developers.cloudflare.com/workers/cache/cache-keys/)
 - [Workers CI/CD](https://developers.cloudflare.com/workers/ci-cd/)
 - [Flagship](https://developers.cloudflare.com/flagship/)
+- [Flagship concepts](https://developers.cloudflare.com/flagship/concepts/)
+- [Flagship binding methods](https://developers.cloudflare.com/flagship/binding/methods/)
 - [Flagship best practices](https://developers.cloudflare.com/flagship/best-practices/)
 - [Flagship client SDK warning](https://developers.cloudflare.com/flagship/sdk/client-provider/)

--- a/docs/cd-stage1-2-design.md
+++ b/docs/cd-stage1-2-design.md
@@ -93,7 +93,7 @@ Routes, domains, and cron triggers are not applied by `versions upload`. Connect
 
 Preview URLs are not isolated staging: a preview of a production-environment version uses that version’s production bindings/settings and is publicly reachable unless Access protects it. Never send real client/matter traffic or credentials merely because the hostname says “preview.”
 
-Version overrides are not an authorization mechanism. They apply only while the version is one of the active deployment’s two versions; an invalid or not-yet-propagated override falls back to normal percentage routing. The trusted zone boundary must block or remove `Cloudflare-Workers-Version-Overrides` from untrusted requests while a 0% version is active. The smoke runner must verify the served version before accepting any response, wait/retry the documented short propagation window, and abort rather than test an unverified version.
+Version overrides are not an authorization mechanism. They apply only while the version is one of the active deployment’s two versions; an invalid or not-yet-propagated override falls back to normal percentage routing. The trusted zone boundary must block or remove `Cloudflare-Workers-Version-Overrides` from untrusted requests for the entire lifetime of every two-version deployment, including a 0% smoke state and every non-zero ramp step. Otherwise a caller who learns a version ID can bypass percentage containment. The smoke runner must verify the served version before accepting any response, wait/retry the documented short propagation window, and abort rather than test an unverified version.
 
 **Smoke proves:** the selected version responds; `GET /api/v1/health` succeeds for `worker-api`; `front-app` index HTML and every referenced critical JS/CSS asset load. For paired changes, confirm the SPA artifact’s baked `VITE_API_BASE_URL` targets the intended API resource and test against the compatible API version.
 
@@ -261,6 +261,7 @@ CI green never authorizes skipping these signals on a gradual path.
 - Typed methods use a safe call-site fallback for known failures; unexpected runtime failures can throw and must be caught into the same safe behavior. A disabled flag serves its configured default variant.
 - Flag targeting and rollout context uses a dedicated opaque rollout key and only necessary non-privileged attributes—never user/client/matter identifiers or content.
 - Flag changes can take up to 30 seconds to propagate globally. Confirm the safe variant before declaring mitigation; if severity cannot tolerate that window, use the binary rollback path.
+- SPA bootstrap decisions are advisory and require a documented bounded lifetime plus refresh path; an already-open client must not retain risky behavior indefinitely after a kill. Authorization and other privileged operations evaluate and enforce the safe decision server-side on every request, never from a cached browser flag alone.
 - Flagship disable ≠ schema safety for future queues/DO/DB.
 - Do not ramp the Worker percentage and Flagship percentage for the same risky path simultaneously.
 
@@ -385,7 +386,7 @@ Ordered conceptual work packages only—this document does not provide YAML, Wra
 3. **Scripts split** — Per-app conceptual paths: **upload** (`versions upload` for the production environment) vs **promote** (`versions deploy`). Stop treating `wrangler deploy` (upload+immediate 100%) as the recurring Stage 1 `main` path.
 4. **Build provenance** — Build `front-app` for the production Cloudflare/Vite environment, record `VITE_API_BASE_URL`, commit SHA, affected base/head, actual Worker name, and returned version ID.
 5. **CI upload job** — On `main` after verify: compute affected build graph → build → upload → publish non-secret release evidence. **No deployment mutation.**
-6. **Credential boundary** — Use a least-privilege Cloudflare token and account ID for upload; never commit or log them. Do not claim token-level “upload-only” isolation unless the Cloudflare permission is verified; the workflow must still contain no promote step, and human deployment authority uses a separately controlled principal.
+6. **Credential boundary** — Use a narrowly scoped Cloudflare token and account ID; never commit or log them. Cloudflare documents a generic `Workers Scripts Write` permission, not an upload-only permission. Treat the CI principal as technically capable of production deployment until a narrower permission is documented and verified. Workflow separation alone is not a security boundary: enforce promotion through a separately protected approval/broker boundary that CI cannot invoke, or explicitly accept and monitor CI as a production deployment principal.
 7. **Smoke + contract checklist** — Probe only `GET /api/v1/health` and the SPA index/referenced assets with synthetic data. Add producer/consumer contract evidence for shared wire changes and verify the SPA’s baked API origin.
 8. **Owners + drill** — Name deployable/contract owners and rota; execute one rollback drill including blocked-rollback and partial-pair decisions.
 9. **Docs pointers** — Link AGENTS/README or deploy notes to this design and operating model.

--- a/docs/cd-stage1-2-design.md
+++ b/docs/cd-stage1-2-design.md
@@ -411,6 +411,7 @@ Ordered conceptual work packages only—this document does not provide YAML, Wra
 
 - Binding decisions: [cd-operating-model.md](./cd-operating-model.md)
 - Architecture assessment: [continuous-deployment-workers.md](./continuous-deployment-workers.md)
+- Implementation evidence and research procedure: [cd-stage1-2-implementation-evidence.md](./cd-stage1-2-implementation-evidence.md)
 - [Versions & deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
 - [Deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)
 - [Preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)

--- a/docs/cd-stage1-2-design.md
+++ b/docs/cd-stage1-2-design.md
@@ -1,0 +1,322 @@
+# Stage 1–2 Continuous Delivery Design
+
+> Implementable design for continuous **delivery of versions** (Stage 1) and **progressive exposure** (Stage 2) for `worker-api` and `front-app`. Bound by [cd-operating-model.md](./cd-operating-model.md). Architecture rationale: [continuous-deployment-workers.md](./continuous-deployment-workers.md).
+
+**Audience:** On-call engineers during a bad deploy; Chat C implementers of Stage 1 CI/upload/promote.
+
+**Hard distinction:** Cloudflare **Worker version / gradual deployment / version affinity / rollback** control which **binary** serves traffic. **Flagship** controls which **behavior** runs inside already-deployed code. Never conflate them.
+
+**Privileged data (standing):** Client/matter identifiers must not appear in log lines, trace attributes, error bodies, cache keys, URL paths/query strings, or Flagship targeting contexts. Correlate with opaque request IDs only.
+
+---
+
+## Assumptions (locked)
+
+| Topic | Decision |
+|-------|----------|
+| Promote authority | Deployable **owner or on-call delegate** (single human). **No dual-control** for Stage 1–2 on this thin surface. |
+| Staging | **Real habit, not a hard CI gate.** Prefer staging or versioned preview smoke before production promote; hotfixes may skip staging with a documented reason. |
+| Upload trigger | Merge/`push` to **`main`** after verify CI green → **affected-only** version upload. PRs stay verify-only. |
+| Orchestration | **GitHub Actions + Turbo `--affected`**. Workers Builds is not the monorepo brain. |
+| Production env | Wrangler **`production`** env for uploaded/promoted versions. |
+| Preview URLs | Stage 1 requires them enabled for smoke (`front-app` today has `preview_urls: false`). |
+| Shared contracts | When Turbo marks both apps affected (typical `@repo/dtos-common` / enums change), upload **both** and promote as **one window**. |
+
+---
+
+## Responsibilities (who does what)
+
+| Actor | Stage 1 | Stage 2 |
+|-------|---------|---------|
+| **CI (GitHub Actions + Turbo)** | Verify; build affected; `versions upload`; publish version IDs + preview URLs. Never moves production traffic. | Same upload path. Does **not** advance percentage ramps. |
+| **Human (owner / on-call)** | Smoke; classify change; promote to 100% (or abort); rollback. | Start/hold/advance/rollback gradual splits; watch version-diff and asset 404s; Flagship kill-switch when applicable. |
+| **Cloudflare platform** | Immutable versions; preview URLs; deployments; rollback to last 100 versions. | Gradual % splits; version affinity; version overrides; per-version metrics; Flagship evaluation (once wired). |
+
+---
+
+## A. Stage 1 — Upload ≠ promote
+
+Goal: every eligible merge produces an immutable Worker **version** with **0% automatic traffic**. A human decides when that version serves production.
+
+### Stage 1 flow
+
+```mermaid
+flowchart LR
+  Merge[Merge_to_main] --> Verify[CI_verify]
+  Verify --> Affected[Turbo_affected]
+  Affected --> Upload[versions_upload]
+  Upload --> Record[Record_version_IDs]
+  Record --> Smoke[Smoke_preview_URL]
+  Smoke --> Human{Human_promote}
+  Human -->|yes| Deploy100[versions_deploy_100pct]
+  Human -->|abort| Idle[Leave_version_idle]
+  Deploy100 --> Watch[Watch_errors_latency]
+```
+
+### Trigger
+
+| Event | Action |
+|-------|--------|
+| `pull_request` | Verify only (existing CI). No production upload. |
+| `push` / merge to `main` (after verify green) | Affected-only **version upload** for deployables that would rebuild for `build` / `deploy`. |
+| Manual / hotfix | Same upload path; promote may skip staging with documented reason (operating-model emergency class). |
+
+**Deployables today:** `worker-api`, `front-app`. Workspace packages (`@repo/dtos-common`, `@repo/enums-common`) are **inputs**, not uploadable artifacts—they ship inside consumer versions.
+
+**Affected honesty:** If Turbo would rebuild the app, upload a new version. If not, do not upload a decorative version. Never “always deploy all.”
+
+### Artifact: what a “version” is
+
+| App | Immutable version contains | Notes |
+|-----|----------------------------|-------|
+| `worker-api` | Worker script + Wrangler bindings/config/compat for that env | Hono gateway; no static asset tree as primary payload. |
+| `front-app` | Worker + **Vite build output** as Workers static assets (`assets.directory`) | Content-hashed JS/CSS filenames; SPA `not_found_handling`. |
+
+A version is **not** an npm package version. Last **100** versions remain eligible for deploy/rollback (platform limit).
+
+Binding *configuration* is versioned with the Worker. **Data** in future KV/R2/DO/D1/Queues is not. Rollback of code does not rewind storage.
+
+### Smoke strategy
+
+| Method | When | Mechanism |
+|--------|------|-----------|
+| **Primary** | After every upload | **Versioned preview URL** (`<version-prefix>-<worker>.<subdomain>.workers.dev`). Requires preview URLs enabled. |
+| **Optional production-shaped** | Before a cautious promote | Put new version in the **active deployment at 0%**, then hit production hostname with `Cloudflare-Workers-Version-Overrides` (override applies only if the version is in the current deployment). |
+| Staging env | Habit for non-trivial / non-hotfix | Promote or upload against Wrangler `staging` before production promote—useful, not a CI hard gate. |
+
+**Smoke proves:** process boots; `worker-api` health/ready succeeds; `front-app` shell (index HTML + critical assets) loads; no obvious 5xx on the smoke paths.
+
+**Smoke cannot prove:** real traffic mix; SPA↔API skew under a gradual split; product correctness on privileged paths (use opaque/synthetic IDs only—never real matter/client identifiers in smoke URLs, logs, or flag context).
+
+### Promote authority
+
+- **Who:** deployable owner or on-call delegate.
+- **How:** Cloudflare dashboard “Promote” or Wrangler `versions deploy` → **100%** in Stage 1.
+- **Dual-control:** not required for Stage 1–2.
+- **Staging:** preferred before production for non-trivial changes; optional for documented hotfixes.
+
+Change-class gates from the operating model still apply: binding topology / secrets shape / future storage migrations are not “routine” promotes.
+
+### Failure modes
+
+| Failure | Effect | Action |
+|---------|--------|--------|
+| CI verify red | No upload | Fix on branch; do not promote anything from that SHA. |
+| Upload fail (one or both apps) | No new eligible version | Fix credentials/config/build; re-run upload. Do not promote a half-pair when both were required. |
+| Smoke fail | Version exists at 0% traffic | Do not promote. Leave idle or roll forward with a fixed upload. |
+| Promote abort (human stops) | Prior version remains 100% | Record why; idle new version is fine. |
+| Partial multi-app success (e.g. `worker-api` uploaded, `front-app` failed) when both required | Incompatible promote window risk | **Promote neither.** Fix and re-upload both; then one promote window. |
+
+### Rollback in Stage 1
+
+| Situation | Version rollback enough? |
+|-----------|--------------------------|
+| Regressed compute/UI; no schema/storage change | **Yes** — promote prior version to 100% (`wrangler rollback` / dashboard). |
+| Bad feature path inside an otherwise healthy new binary (once Flagship exists) | Prefer **Flagship disable**; rollback secondary. |
+| Irreversible storage / message schema migration | **No** — forward-fix / restore. (Products not in use yet; document so drills stay honest.) |
+| Account-level DNS / routes / unbound config / secret **contents** wrong outside the version | **No** — fix that surface; Worker rollback alone may not undo it. |
+| Binding deleted/modified so platform refuses rollback | **No** — platform blocks unsafe rollbacks (e.g. missing KV/R2/queue binding targets; DO class lifecycle gaps). |
+
+Rollback creates a new deployment selecting a prior version. It does not rewind data.
+
+### Definition of Done — Stage 1
+
+- [ ] CI remains the merge gate (boundaries, lint, format, affected typecheck/build).
+- [ ] On `main`, affected deployables get **`versions upload` without automatic 100% traffic**; practiced until boring on a non-critical path.
+- [ ] Preview URLs enabled; smoke habit uses preview URL (and optionally 0% + override).
+- [ ] Staging or preview habit used before production promote for non-hotfix changes.
+- [ ] **Rollback drill** completed; time-to-mitigate measured; “what rollback does not undo” understood.
+- [ ] Named owners for `worker-api`, `front-app`, and shared contracts (`@repo/dtos-common` / `@repo/enums-common`).
+- [ ] Package scripts / CI conceptually split **upload** vs **promote**; `wrangler deploy` (upload+100%) is not the Stage 1 default path for `main`.
+
+Exit criteria align with operating-model **Stage 0 → 1**.
+
+---
+
+## B. Stage 2 — Progressive exposure
+
+Goal: production promotes can **split traffic** between two versions; humans advance using version-diff signals. Upload path stays Stage 1.
+
+### Stage 2 flow
+
+```mermaid
+flowchart LR
+  Uploaded[Uploaded_versions] --> StartSplit[Human_start_pct_split]
+  StartSplit --> Affinity[front_app_version_affinity]
+  Affinity --> WatchSignals[Watch_version_diff_and_404s]
+  WatchSignals --> Decide{Pause_hold_advance_rollback}
+  Decide -->|advance| NextPct[Raise_new_version_pct]
+  Decide -->|rollback| Prior100[Prior_version_100pct]
+  Decide -->|feature_fault| FlagOff[Flagship_kill_switch]
+  NextPct --> WatchSignals
+```
+
+### Ramp philosophy
+
+| Deployable | Ramp | Affinity |
+|------------|------|----------|
+| `worker-api` | Short percentage ladder for non-trivial changes (e.g. 10 → 50 → 100). Immediate 100% only for trivial/hotfix when delay risk exceeds cutover risk (document the skip). | Nice-to-have for sticky debugging; **not mandatory** for pure JSON API responses. |
+| `front-app` | Same ladder bias for non-trivial UI/asset changes. | **Mandatory** whenever traffic is split. |
+
+Regional geography is not a primary lever.
+
+### Version affinity for `front-app` (mandatory on splits)
+
+Without affinity, each request is independently routed by percentage. Vite content-hashed assets then fail as: HTML from version A references `index-a1b2c3d4.js`, browser fetch lands on version B → **404** → broken page.
+
+**Requirement:** set `Cloudflare-Workers-Version-Key` on inbound requests to `front-app` (preferred: zone **Transform Rule** from a stable session/cookie value that is **not** a client/matter identifier). Platform hashes the key; you do not pick which version a key maps to. As percentages rise, keys already on the new version stay there.
+
+Affinity pins **within** `front-app` only. It does **not** lock `front-app` and `worker-api` to the same generation.
+
+### SPA ↔ API skew controls
+
+| Control | Rule |
+|---------|------|
+| Compatibility window | HTTP DTOs in `@repo/dtos-common`: expand/contract; **N and N+1 must coexist** during independent ramps. |
+| Promote order (additive) | Upload/promote **API support first**, then SPA that depends on it. |
+| Promote order (removal) | Migrate/remove SPA usage first, then remove API shape. |
+| Same-PR discipline | Additive wire changes that need consumer updates land in the **same PR**; still yield multiple uploadable versions. |
+| Do not ship together | Breaking removals with consumers still live; binding topology with “routine” UI; anything labeled migration as a silent co-ramp. |
+
+### Signals — pause / hold / advance / roll back
+
+Tied to the operating-model observability bar (also Stage 2 practice for **manual** gradual promotes):
+
+| Signal | Use |
+|--------|-----|
+| Version-diff **error / exception** rate | New version worse → **pause** or **rollback**. |
+| Version-diff **latency** (at least p95) | Sustained regression → **hold**; do not advance. |
+| `front-app` **asset 404** rate | Classic affinity/skew → **pause**; verify affinity; often **rollback** the SPA split. |
+| Opaque **request ID** correlation `front-app` → `worker-api` | Debug without privileged identifiers. |
+
+**Targets:** time-to-detect ≤ **5 minutes** after a ramp step; time-to-mitigate ≤ **15 minutes**.
+
+| Decision | When |
+|----------|------|
+| **Advance** | Version-diff healthy for the bake window; no asset-404 spike; no known contract alarm. |
+| **Hold** | Ambiguous signal; waiting for bake; coordinated second app not ready. |
+| **Pause** (keep current split) | Investigating; do not raise %. |
+| **Rollback** (prior version 100%) | Confirmed binary regression or SPA 404 skew; see runbooks. |
+
+CI green never authorizes skipping these signals on a gradual path.
+
+### Where Flagship sits in Stage 2
+
+| Lever | Controls | Sticky how | Use for |
+|-------|----------|------------|---------|
+| Workers gradual deployment | Which **Worker version** serves the request | Version affinity header | Blast radius of **code** just shipped |
+| Flagship % / targeting | Which **behavior/config** runs inside deployed code | Consistent hash on a stable, **non-privileged** attribute | Feature exposure & **kill-switch** without redeploy |
+
+- Evaluate on **`worker-api` Flagship binding** (edge-local; no app-managed token). `front-app` learns via API/bootstrap payload.
+- **Do not** ship Cloudflare API tokens in a browser OpenFeature client provider (docs: not recommended for public apps).
+- Every evaluation supplies a **safe default**; failure → safe-off.
+- Flag targeting context: no matter/client identifiers.
+- Flagship disable ≠ schema safety for future queues/DO/DB.
+
+Until Flagship is wired, incomplete features stay off by code path or do not merge—do not invent a second SPA flag SaaS.
+
+### Manual vs later Stage 3 (name only)
+
+| Remains manual in Stage 2 | May automate later (Stage 3+) — do not design here |
+|---------------------------|-----------------------------------------------------|
+| Start / advance / pause percentage | Metric-gated auto-ramp policies |
+| Rollback / Flagship kill | Auto-pause robots |
+| Change-class “is this routine?” judgment | Policy engine for routine vs migration |
+| Coordinated multi-app promote windows | Richer multi-Worker order playbooks |
+
+---
+
+## C. Runbooks
+
+### Bad error-rate after promote
+
+1. Confirm version-diff (new vs old), not only global spike.
+2. If new feature/path only → **Flagship disable** (if wired); else disable by config/code forward-fix.
+3. If regressed correct old behavior, no storage/schema change → **Worker version rollback** to prior 100%.
+4. If irreversible migration suspected → **forward-fix**; do not blind-rollback.
+5. Mitigate within 15 minutes; leave a short note (what signal, which lever).
+
+### Asset 404 spike during `front-app` ramp
+
+1. Treat as **affinity or asset skew** until proven otherwise.
+2. **Pause** further % advances immediately.
+3. Verify `Cloudflare-Workers-Version-Key` is present and stable for browsers fetching HTML and hashed assets.
+4. If affinity missing/broken or 404s continue → **rollback** `front-app` to prior version 100%.
+5. Do not “fix” by redeploying API first—this is an SPA binary-split symptom.
+
+### Suspected contract skew (SPA ↔ API)
+
+1. Pause promotes on **both** apps.
+2. Compare which versions are live (%); check whether an additive/removal landed without expand window.
+3. Prefer aligning versions (promote the compatible pair or roll the incompatible side back).
+4. Flag off risky paths if Flagship covers them.
+5. Debugging: opaque request IDs only—no matter/client IDs in logs or traces.
+
+### Mitigation precedence (decision table)
+
+| Situation | Prefer first | Then |
+|-----------|--------------|------|
+| New feature/path causing errors; new version otherwise healthy | **Flagship kill-switch / disable** | Version rollback if flag insufficient |
+| Regressed correct old behavior; no schema/storage change | **Worker version rollback** | Forward-fix if rollback blocked |
+| Bad / irreversible storage or message schema migration | **Forward-fix** (or product restore) | Not blind Worker rollback |
+| Partial multi-app incompatible ramp | Pause; align versions; flag off | Rollback the offending side |
+| SPA asset 404s during split | Pause; fix/verify affinity; **SPA version rollback** | Re-ramp only with affinity proven |
+| CI/upload/smoke failure | Do not promote | Re-upload after fix |
+
+---
+
+## D. Out of scope until later
+
+- Queue / Durable Object / KV / R2 / D1 migration CD playbooks
+- Auto-100% traffic on every merge
+- Flagship browser evaluate tokens / client provider in `front-app`
+- Workers Builds as primary monorepo orchestrator
+- Dual-control promote gates
+- Full Stage 3 auto-ramp / change-class automation design
+- Multi-Worker service-binding RPC order playbooks as the default path
+- Scheduled release trains; regional rollouts as primary CD lever
+- Always-deploy-all (rejected by operating model)
+
+---
+
+## E. Implementation handoff — Stage 1 only
+
+Ordered work packages for Chat C. Conceptual areas only—no YAML or app feature code in this doc.
+
+1. **Preview URLs** — Enable for `worker-api` and `front-app`; confirm access posture for smoke.
+2. **Scripts split** — Per-app conceptual paths: **upload** (`versions upload` + production env) vs **promote** (`versions deploy`). Stop treating `wrangler deploy` (upload+immediate 100%) as the Stage 1 default for `main`.
+3. **CI upload job** — On `main` after verify: Turbo `--affected` → build → upload → publish version IDs and preview URLs (artifacts / job summary). **No auto-promote.**
+4. **Secrets** — `CLOUDFLARE_API_TOKEN` + account id for upload (least privilege); never commit; no privileged payload in logs. Promote via human-gated `workflow_dispatch` and/or dashboard.
+5. **Smoke checklist** — Minimal probes: `worker-api` health/ready; `front-app` index/shell. Synthetic IDs only.
+6. **Owners + drill** — Named owners/rota; execute and record one rollback drill (TTM).
+7. **Docs pointers** — Link AGENTS/README (or deploy notes) to this design + operating model.
+
+### Do not build in Stage 1
+
+- Gradual percentage automation or metric-gated advance
+- Version affinity Transform Rules (Stage 2)
+- Flagship wiring as a required production gate
+- Workers Builds replacing GitHub Actions + Turbo
+- Always-deploy-all
+- Dual-control approval gates
+- Queue/DO/storage migration playbooks
+- Browser Flagship tokens
+- Auto-100% on merge
+
+---
+
+## References
+
+- Binding decisions: [cd-operating-model.md](./cd-operating-model.md)
+- Architecture assessment: [continuous-deployment-workers.md](./continuous-deployment-workers.md)
+- [Versions & deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
+- [Deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)
+- [Preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)
+- [Version overrides](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/)
+- [Gradual deployments](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/)
+- [Version affinity](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/)
+- [Rollbacks](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/)
+- [Workers CI/CD](https://developers.cloudflare.com/workers/ci-cd/)
+- [Flagship](https://developers.cloudflare.com/flagship/)
+- [Flagship best practices](https://developers.cloudflare.com/flagship/best-practices/)
+- [Flagship client SDK warning](https://developers.cloudflare.com/flagship/sdk/client-provider/)

--- a/docs/cd-stage1-2-design.md
+++ b/docs/cd-stage1-2-design.md
@@ -70,7 +70,7 @@ flowchart LR
 
 **Affected honesty:** Record the base/head range. If Turbo cannot resolve it or widens to everything, stop or explicitly upload both; never silently narrow. If an app would rebuild, upload a new version. If not, do not upload a decorative version.
 
-**Bootstrap exception:** this recurring flow assumes the Worker has been published before. Cloudflare requires the first upload of a new Worker to use `wrangler deploy`; `versions upload` fails for a first publish.
+**Bootstrap exception:** this recurring flow assumes the Worker has been published before. Cloudflare requires the first upload of a new Worker to use `wrangler deploy`; `versions upload` fails for a first publish. Bootstrap before production routes/domains or user traffic are attached.
 
 ### Artifact: what a “version” is
 
@@ -380,7 +380,7 @@ Mitigation is complete only when the expected deployment is active, production p
 
 Ordered conceptual work packages only—this document does not provide YAML, Wrangler configuration, or application code:
 
-1. **Bootstrap inventory** — Confirm both `<name>-production` Workers already exist. A first publish uses the bootstrap deploy path; only recurring releases use `versions upload`.
+1. **Bootstrap inventory** — Confirm both `<name>-production` Workers already exist. A first publish uses the bootstrap deploy path before production routes/domains or user traffic are attached; only recurring releases use `versions upload`.
 2. **Protected smoke path** — Keep preview URLs disabled unless Cloudflare Access protects them. When enabled, account for their missing logs and zone controls. Define the trusted 0%-override alternative and served-version verification.
 3. **Scripts split** — Per-app conceptual paths: **upload** (`versions upload` for the production environment) vs **promote** (`versions deploy`). Stop treating `wrangler deploy` (upload+immediate 100%) as the recurring Stage 1 `main` path.
 4. **Build provenance** — Build `front-app` for the production Cloudflare/Vite environment, record `VITE_API_BASE_URL`, commit SHA, affected base/head, actual Worker name, and returned version ID.

--- a/docs/cd-stage1-2-design.md
+++ b/docs/cd-stage1-2-design.md
@@ -19,7 +19,7 @@
 | Upload trigger | Target state: merge/`push` to **`main`** after verify CI green → **affected-only** version upload. PRs stay verify-only. The repository has no upload job today. |
 | Orchestration | **GitHub Actions + Turbo `--affected`**. Workers Builds is not the monorepo brain. |
 | Production env | Wrangler **`production`** env. The actual Worker resources are currently `worker-api-production` and `front-app-production`; records and commands use the actual name. |
-| Preview URLs | `front-app` explicitly disables them today; `worker-api` does not pin the setting. If enabled for Stage 1, previews must be Access-protected because enabled URLs are public and have no Workers Logs, `wrangler tail`, or Logpush. |
+| Preview URLs | `front-app` explicitly disables them. `worker-api` leaves both `workers_dev` and `preview_urls` unset; current documented defaults enable both. Before production uploads, explicitly disable preview URLs or verify Cloudflare Access protection. Enabled previews are public and have no Workers Logs, `wrangler tail`, or Logpush. |
 | Shared contracts | When Turbo marks both apps affected, upload both from the same commit. Promotions are ordered per Worker and independently verified; Cloudflare provides no multi-Worker transaction. |
 | Stage 2 SPA gate | Blocked today: `front-app` is assets-only on `workers.dev`, where Transform Rules are unavailable. A zone route/custom domain plus first-request affinity must exist before a SPA split. |
 
@@ -54,7 +54,8 @@ flowchart LR
   Preview --> Human{Human_promote}
   Override --> Human
   Human -->|yes| Deploy100[versions_deploy_100pct]
-  Human -->|abort| Idle[Leave_version_idle]
+  Human -->|abort_after_preview| Idle[Leave_version_inactive]
+  Human -->|abort_after_0pct| Restore[Restore_prior_100_or_bound_0pct]
   Deploy100 --> VerifyActive[Verify_active_version_and_signals]
 ```
 
@@ -133,7 +134,8 @@ For a coordinated HTTP change, Cloudflare cannot promote both Workers atomically
 | Upload fail | Zero or one inactive versions may exist | Do not promote a required pair. Fix the failed upload, then verify both versions have the same commit/build provenance; do not re-upload the successful immutable version without cause. |
 | Smoke fail before 0% deployment | Version exists outside active deployment | Do not promote. Leave it idle and upload a fixed version. |
 | Smoke fail after 0% deployment | New version is active at 0%; normal traffic remains on old 100%, but overrides can select new | Restore the prior single-version deployment or leave 0% only for a bounded investigation; restrict the override path. |
-| Promote abort (human stops) | Prior version remains 100% | Record why; idle new version is fine. |
+| Abort after protected preview | Prior single-version deployment remains active | Record why; the uploaded version stays inactive. |
+| Abort after a 0% deployment | Old version still receives normal traffic at 100%, but the new version remains in the active two-version deployment and overrides can select it | Restore the prior single-version deployment, or authorize a bounded 0% investigation with override-header controls. Never call this version idle. |
 | Partial multi-app promote | One Worker changed; no automatic undo | Stop further changes. If the state is contract-compatible, hold and repair the missing step; otherwise use the compatibility matrix to roll back the changed side or complete the safe counterpart. Never assume joint rollback. |
 | Wrong version or concurrent change detected | Planned previous/new pair is no longer active | Hold. Re-read deployment history and either restore the known-good version or build a new plan from current state. |
 

--- a/docs/cd-stage1-2-implementation-evidence.md
+++ b/docs/cd-stage1-2-implementation-evidence.md
@@ -6,6 +6,8 @@
 
 **Last evidence review:** 2026-08-08. Cloudflare behavior changes; reverify every platform claim immediately before implementation. During the original review, Context7 was quota-blocked, so no conclusion depends on Context7 output. Official Cloudflare Documentation MCP results and direct official pages were used.
 
+**Contents for future Cursor chats:** platform ledger (§2), repo reality (§3), acceptance crosswalk (§4), research procedure (§5), uncertainties (§6), blockers (§7), source index (§8), how to `@`-load this pack (§9), vocabulary (§10), state/control diagrams (§11), evidence/release schemas (§12), copy-paste conversation starters (§13), anti-patterns (§14), and JSON handoff shapes (§15). The design doc also has Mermaid flows; this guide restates the control model as tables/ASCII so agents can reason without depending on a renderer.
+
 ---
 
 ## 1. Source hierarchy
@@ -21,6 +23,8 @@ Classify every claim as **platform-documented**, **repo-observed**, **operating 
 ---
 
 ## 2. Platform evidence ledger
+
+Unless explicitly labeled otherwise, each sourced bullet below is **platform-documented**. Derived controls are **operating policy**; absence-of-guarantee statements are **unverified** and must not be promoted into platform facts.
 
 ### Versions, deployments, and triggers
 
@@ -38,7 +42,7 @@ Classify every claim as **platform-documented**, **repo-observed**, **operating 
 - `Cloudflare-Workers-Version-Key` is hashed to select a version; assignments remain monotonic as the new-version percentage increases. Operators do not select a key’s version. Source: [Version affinity](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/).
 - HTML and content-hashed assets can route to different versions and 404 without affinity. `front-app` cannot split until first-request-through-assets affinity and asset-404 visibility are proven. Source: [Static assets](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/#static-assets).
 - A cookie created by the first response cannot pin the first randomly routed request. The affinity key must pre-exist the first HTML request. Source: [Anonymous applications](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/#anonymous-or-cookieless-applications).
-- Transform Rules require a route on a controlled zone and are unavailable on `workers.dev`. The current `front-app` posture therefore blocks Stage 2. Source: [Choose a version key](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/#choose-a-version-key).
+- Transform Rules require a route on a controlled zone and are unavailable on `workers.dev`. The current `front-app` posture therefore blocks Stage 2. Source: [Static-assets gradual rollouts](https://developers.cloudflare.com/workers/static-assets/routing/advanced/gradual-rollouts/).
 - The affinity header contributes to Workers cache partitioning. Use a dedicated random rollout value—never an auth token, user/client/matter identifier, filename, or privileged value. Source: [Workers cache keys](https://developers.cloudflare.com/workers/cache/cache-keys/).
 
 ### Preview URLs and version overrides
@@ -48,20 +52,20 @@ Classify every claim as **platform-documented**, **repo-observed**, **operating 
 - `preview_urls` defaults to `workers_dev`; current documented behavior enables both when neither is configured. Omission is not a deny. Source: [Preview toggle](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/#toggle-preview-urls-enable-or-disable).
 - An override applies only when its version is in the current two-version deployment; a new version may be assigned 0%. A 0% smoke is a deployment mutation, not upload. Source: [Override smoke](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/#smoke-test-example).
 - Invalid, unavailable, or not-yet-propagated overrides fall back to percentage routing; recent changes can take up to a couple of seconds to become globally available. The smoke runner must verify the served version and fail closed. Source: [Verify overrides](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/#verify-that-version-overrides-were-applied).
-- External requests can supply the override header. Derived control: block/remove untrusted overrides throughout every two-version deployment, or a caller with a version ID can bypass percentage containment. Source: [Version overrides](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/).
+- External requests can supply the override header. **Operating policy derived from documented behavior:** block/remove untrusted overrides throughout every two-version deployment, or a caller with a version ID can bypass percentage containment. Source: [Version overrides](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/).
 
 ### Rollback
 
 - Rollback creates a new single-version deployment at 100%; from a split it replaces both versions. Verify the active deployment before declaring mitigation. Source: [Rollbacks](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/).
 - Connected resources and stored data are not rewound. Never describe rollback as restoring storage, secret contents, triggers, routes, DNS, or external configuration. Source: [Rollback bindings](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/#bindings).
-- Missing resource targets and Durable Object lifecycle changes can block rollback. The runbook needs a compatible forward-fix path.
-- Deployments are per Worker; no official multi-Worker transaction was found. `worker-api` and `front-app` promotion/rollback are ordered and independently verified.
+- Missing resource targets and Durable Object lifecycle changes can block rollback. The runbook needs a compatible forward-fix path. Source: [Rollback bindings](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/#bindings).
+- **Unverified absence plus operating policy:** no official multi-Worker transaction was found. Treat `worker-api` and `front-app` promotion/rollback as ordered, independently verified operations.
 
 ### Observability
 
 - Invocation errors are runtime outcomes, not HTTP status codes. A successful invocation can return application 5xx. Stage 2 needs both signals. Source: [Invocation statuses](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/#invocation-statuses).
 - Wall time includes I/O and `waitUntil`; it is not final-byte response latency. Name every performance signal by what it measures. Source: [Metrics and analytics](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/).
-- Sampled/aggregated quantiles and recent-minute lag require a declared bake and sample count. Delayed or insufficient evidence means hold.
+- Sampled/aggregated quantiles and recent-minute lag require a declared bake and sample count. Delayed or insufficient evidence means hold. Source: [Metrics and analytics](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/).
 - Version identity is available through Logpush `ScriptVersion` and the version metadata binding. Verify actual dashboard/export dimensions; do not assume every default chart can gate by version. Sources: [Gradual observability](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/#observability), [version metadata](https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata/).
 - Cloudflare recommends Analytics Engine or Logpush for asset-404 monitoring. Treat this as an explicit Stage 2 prerequisite. Source: [Affinity testing](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/#testing).
 
@@ -79,6 +83,8 @@ Classify every claim as **platform-documented**, **repo-observed**, **operating 
 
 ## 3. Repository reality map
 
+Every bullet in this section is **repo-observed** as of the evidence-review date and must be rechecked after relevant repository changes.
+
 - **CI:** [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) verifies boundaries, lint, format, affected typecheck/build; it has no upload/promote job. Full history supports affected correctness. Stage 1 automation is target state.
 - **Deploy scripts:** both app package files use `wrangler deploy --env production`, so current deploy is upload plus immediate 100%.
 - **Turbo:** [`turbo.json`](../turbo.json) models affected builds; `front-app#deploy` depends on its build. Use the affected **build** graph to select uploads.
@@ -95,17 +101,19 @@ Classify every claim as **platform-documented**, **repo-observed**, **operating 
 
 ---
 
-## 4. Implementation order and acceptance evidence
+## 4. Acceptance-evidence crosswalk
 
-### Stage 1
+This section is **operating policy** and follows the authoritative Stage 1 work-package order in [cd-stage1-2-design.md](./cd-stage1-2-design.md#e-implementation-handoff--stage-1-only); it does not define a second implementation plan.
 
-1. **Inventory/bootstrap:** confirm actual Worker names, previous publication, routes/domains, and active deployments. Evidence: names, current version/deployment, bootstrap status.
-2. **Credential/authority boundary:** Cloudflare documents generic `Workers Scripts Write`, not upload-only authorization. Treat CI as deployment-capable until a narrower permission is verified. Evidence: principal inventory, dated permission source, approval/broker path CI cannot invoke, revocation owner, audit source—never token values.
-3. **Affected selection:** record base/head and fail closed on an unresolved comparison. Explicit widening to both apps is safe; silent narrowing is not. Evidence: SHAs, affected packages, selected deployables, build result, widening reason.
-4. **Immutable release record:** record commit, actual Worker, version ID/tag, build inputs, SPA API origin, and previous deployment. Exclude credentials, preview bearer values, client/matter IDs, and privileged content.
-5. **Protected smoke:** use Access-protected preview for boot/shell, or trusted 0%-override smoke for zone behavior. Block untrusted overrides throughout the two-version deployment and verify the served version. Evidence: method, version, synthetic probes, result, and restoration after abort.
-6. **Manual promote/rollback drill:** re-read active state before mutation; one operator and one in-flight change per Worker. Evidence: before/after deployments, authority, probes, TTD/TTM, compatible rollback target, and external state not restored.
-7. **Contract gate:** for shared wire changes, prove old/new producer-consumer combinations. Additive API support reaches 100% before the dependent SPA. Removal waits for measured open-client retirement.
+1. **Bootstrap inventory:** evidence includes actual Worker names, previous publication, routes/domains, and active deployments.
+2. **Protected smoke path:** evidence includes Access posture or trusted 0%-override controls, served-version verification, synthetic probes, and restoration after abort.
+3. **Scripts split:** evidence shows recurring upload and human deployment are distinct paths; bootstrap is explicitly excluded.
+4. **Build provenance:** evidence includes commit, affected base/head, actual Worker, version ID/tag, build inputs, and SPA API origin.
+5. **CI upload job:** evidence includes affected packages, selected deployables, build/upload result, and reason for explicit widening. Silent narrowing is forbidden.
+6. **Credential boundary:** both [create version](https://developers.cloudflare.com/api/resources/workers/subresources/beta/subresources/workers/subresources/versions/methods/create/) and [create deployment](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/deployments/methods/create/) use the broad Workers script-edit authority. No upload-only permission was documented. Require a protected approval/broker boundary CI cannot invoke. Evidence includes principal inventory, dated endpoint/permission sources, approval path, revocation owner, and audit source—never token values.
+7. **Smoke and contract checklist:** evidence includes existing health/asset probes and old/new producer-consumer compatibility. Additive API support reaches 100% before a dependent SPA; removal waits for measured open-client retirement.
+8. **Owners and drill:** evidence includes named app/contract owners, one operator per change, rollback/blocked-rollback results, before/after deployments, probes, and TTD/TTM.
+9. **Documentation pointers:** evidence includes current cross-links from implementation surfaces to the operating model, design, and this evidence guide.
 
 ### Stage 2 entry gate
 
@@ -135,7 +143,7 @@ No fixed 10→50→100 ladder is authoritative. Choose percentages from traffic 
    - Preview publicity/Access/log limitations/defaults and override fallback/propagation.
    - Rollback resource/data constraints and Durable Object lifecycle.
    - Invocation versus HTTP status, wall time, version metadata, and `ScriptVersion`.
-   - Version/create-deployment API permissions and `Workers Scripts Write`.
+   - Version/create-deployment API permissions and `Workers Scripts Edit`.
    - Flagship binding defaults/errors, disabled variant, propagation, rollout bucketing, browser token, beta/SLA.
 3. Use Context7 independently: resolve the official Cloudflare Workers project ID first, then query one concept at a time. If unavailable or quota-blocked, record it; an attempted call is not corroboration.
 4. Fetch the official page Markdown form ending in `/index.md` when semantic search returns only a partial chunk or changelog.
@@ -185,20 +193,30 @@ If a required fact remains uncertain, block the stage or add a control that does
 
 ---
 
-## 7. Implementation blockers
+## 7. Implementation blockers by stage
 
-1. Named deployable owner/on-call rota for both apps.
-2. Named contract owner for shared DTOs/enums.
-3. Verified remote names, active deployments, routes/domains, preview status, and Access policy.
-4. Promotion authority CI cannot invoke, or explicit acceptance/monitoring of CI deployment authority.
-5. Contract compatibility evidence for shared wire changes.
-6. Protected smoke with served-version verification and override-header control.
-7. Zone route/custom domain plus first-request SPA affinity.
-8. Version-attributed runtime, HTTP, performance, and asset-404 signals.
-9. End-to-end opaque request correlation.
-10. Ramp bake/sample/advance/rollback thresholds and incident owner.
-11. Client-retirement measurement before API contract removal.
-12. Flagship beta/fallback acceptance, bounded SPA bootstrap freshness, and server-side enforcement if it becomes load-bearing.
+### Stage 1 exit blockers
+
+1. Named deployable owner/on-call rota and named shared-contract owner.
+2. Verified remote names, active deployments, routes/domains, preview status, and Access policy.
+3. A protected promotion boundary the CI upload principal cannot invoke.
+4. Contract compatibility evidence for shared wire changes.
+5. Protected smoke with served-version verification and override-header control.
+6. Successful rollback and blocked-rollback drills with recorded TTD/TTM.
+
+### Stage 2 entry blockers
+
+1. Zone route/custom domain plus first-request SPA affinity.
+2. Version-attributed runtime, HTTP, performance, and asset-404 signals.
+3. End-to-end opaque request correlation.
+4. Ramp bake/sample/advance/rollback thresholds and incident owner.
+5. Client-retirement measurement before API contract removal.
+
+### Optional Flagship adoption blockers
+
+1. Explicit public-beta/no-SLA risk and fallback acceptance.
+2. Safe configured default variant and safe call-site/runtime failure behavior.
+3. Bounded SPA bootstrap freshness and server-side enforcement for privileged operations.
 
 A planned implementation is not completion. Stage exit criteria remain unchecked until evidence is real.
 
@@ -210,6 +228,7 @@ A planned implementation is not completion. Stage exit criteria remain unchecked
 - [Deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)
 - [Gradual deployments](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/)
 - [Version affinity](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/)
+- [Static-assets gradual rollouts](https://developers.cloudflare.com/workers/static-assets/routing/advanced/gradual-rollouts/)
 - [Version overrides](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/)
 - [Preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)
 - [Rollbacks](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/)
@@ -218,9 +237,326 @@ A planned implementation is not completion. Stage exit criteria remain unchecked
 - [Version metadata](https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata/)
 - [Workers cache keys](https://developers.cloudflare.com/workers/cache/cache-keys/)
 - [API token permissions](https://developers.cloudflare.com/fundamentals/api/reference/permissions/)
+- [Create Worker version](https://developers.cloudflare.com/api/resources/workers/subresources/beta/subresources/workers/subresources/versions/methods/create/)
+- [Create deployment](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/deployments/methods/create/)
 - [Flagship](https://developers.cloudflare.com/flagship/)
 - [Flagship concepts](https://developers.cloudflare.com/flagship/concepts/)
 - [Flagship binding methods](https://developers.cloudflare.com/flagship/binding/methods/)
 - [Flagship percentage rollouts](https://developers.cloudflare.com/flagship/targeting/percentage-rollouts/)
 - [Flagship client provider](https://developers.cloudflare.com/flagship/sdk/client-provider/)
 - [Flagship public beta](https://developers.cloudflare.com/changelog/post/2026-05-26-public-beta/)
+
+---
+
+## 9. How to use this guide in Cursor
+
+Load this file **with** the operating model and design, not instead of them. Suggested `@` order for an implementation or design chat:
+
+1. `@docs/cd-operating-model.md` — decisions already locked
+2. `@docs/cd-stage1-2-design.md` — flows, runbooks, Stage 1 work packages
+3. `@docs/cd-stage1-2-implementation-evidence.md` — this evidence pack
+4. Only if architecture is in dispute: `@docs/continuous-deployment-workers.md`
+
+Then constrain the agent:
+
+- Stage 1–2 only; no Stage 3+ auto-ramp design
+- Docs/process only unless the user explicitly asks for CI YAML, Wrangler, or app code
+- Reverify every **platform-documented** claim via Cloudflare Documentation MCP + official `/index.md` before coding against it
+- Classify every new claim; never promote operating targets (TTD/TTM) into Cloudflare SLAs
+- Prefer diagrams and schemas in this guide when explaining state; do not invent a second decision memo
+
+**Stale wording elsewhere:** [continuous-deployment-workers.md](./continuous-deployment-workers.md) once summarized rollbacks as “100 versions.” Prefer the precise split here and in the design: **100 most recent uploads** for deployment selection vs **100 most recently published** for rollback. Prefer this guide + design over collapsed phrasing in older assessment prose.
+
+---
+
+## 10. Shared vocabulary
+
+| Term | Exact meaning in this monorepo |
+|------|--------------------------------|
+| **Upload** | `wrangler versions upload` (or equivalent API): creates an immutable version; does **not** change the active deployment. |
+| **Promote / deploy** | Creates a deployment that can serve traffic. Stage 1 promote = new version at **100%**. |
+| **0% smoke** | A **deployment** that includes the new version at 0% so overrides can target it. Not upload; not Stage 2 progressive exposure. |
+| **Stage 2 split** | Two-version deployment with new version **> 0% and < 100%**. |
+| **Hold** | Make **no** deployment mutation. Not a platform “pause” object. |
+| **Rollback** | New single-version deployment at 100% selecting a prior published version. Does not rewind storage/secrets/routes/DNS. |
+| **Affinity key** | Dedicated opaque `Cloudflare-Workers-Version-Key` value, present before first HTML; never client/matter/auth secret. |
+| **Override** | `Cloudflare-Workers-Version-Overrides` for trusted smoke only; fail-open to % routing if invalid/unpropagated. |
+| **Flagship** | In-process behavior flagging; never substitutes for upload/promote/rollback. |
+| **Actual Worker name** | e.g. `worker-api-production`, not only the package name `worker-api`. |
+
+---
+
+## 11. State model and control diagrams
+
+These are **operating-policy visualizations** of platform-documented primitives. Prefer them (and the Mermaid flows already in the design doc) over inventing a new state language mid-chat.
+
+### 11.1 Per-Worker version / deployment states
+
+| State | Traffic meaning | How you enter | Valid next moves |
+|-------|-----------------|---------------|------------------|
+| `never_published` | No Worker yet | New script | Bootstrap with first `wrangler deploy` only (not recurring `versions upload`) |
+| `active_100` | One version at 100% | Promote, complete, rollback, or bootstrap | Upload new inactive version; start Stage 2 split |
+| `inactive_uploaded` | New version exists; **not** in active deployment | `versions upload` | Leave idle; promote to 100%; or deploy at 0% for override smoke |
+| `two_version_0` | New version in deployment at 0% | Production-shaped smoke | Abort and restore prior 100%; promote new to 100%; raise above 0% (enters Stage 2) |
+| `stage2_split` | Two versions; new in (0%, 100%) | Human starts non-zero split | Hold (no mutation); advance %; complete to new 100%; rollback to prior 100% |
+
+Transition summary (read as “from / event / to”):
+
+1. `never_published` / bootstrap deploy / `active_100`
+2. `active_100` / versions upload / `inactive_uploaded`
+3. `inactive_uploaded` / promote 100% / `active_100`
+4. `inactive_uploaded` / deploy new at 0% / `two_version_0`
+5. `two_version_0` / abort restore prior / `active_100`
+6. `two_version_0` / promote new 100% / `active_100`
+7. `two_version_0` / raise new above 0% / `stage2_split`
+8. `active_100` / start non-zero split / `stage2_split`
+9. `stage2_split` / hold / `stage2_split`
+10. `stage2_split` / advance / `stage2_split`
+11. `stage2_split` / complete or rollback / `active_100`
+
+Upload is not a 0% deploy. A 0% deploy is not Stage 1 promote. Stage 1 promote is not a Stage 2 split. Mixing those four is the most common agent error.
+
+### 11.2 Stage 1 decision spine
+
+1. Merge to `main` after verify is green.
+2. Compute the Turbo affected **build** graph; record base and head.
+3. If the graph is unresolved or would silently narrow: stop, or explicitly widen both deployables and record why.
+4. Otherwise run `versions upload` only (no traffic mutation).
+5. Record version IDs and provenance (actual Worker name, commit, SPA API origin when relevant).
+6. Smoke:
+   - Access-protected preview: boot or shell only.
+   - Zone behavior required: deploy new at 0%, trusted override, verify served version, fail closed if unverified.
+7. Human decision:
+   - Promote 100%, then verify active deployment and probes.
+   - Abort after preview: leave the version inactive.
+   - Abort after 0%: restore prior 100% so the 0% deployment does not linger unbound.
+
+### 11.3 Stage 2 operator loop
+
+1. If the Stage 2 entry gate fails, remain Stage 1 only.
+2. Human starts a non-zero split and records bake, sample, and rollback thresholds first.
+3. Watch version-attributed runtime failures, application HTTP 5xx, accurately named latency, and asset 404s.
+4. Decide:
+   - **hold** — no control-plane change; keep watching.
+   - **advance** — raise new-version percent; return to watch.
+   - **complete** — new version at 100%; verify active state.
+   - **rollback** — prior version at 100%; verify active state.
+
+Insufficient bake, sample, or delayed metrics means **hold**, never advance on hope.
+
+### 11.4 SPA ↔ API promote and rollback order
+
+**Additive contract**
+
+1. Upload API and SPA versions from the same commit when the wire surface is shared.
+2. Promote API support to 100% and verify the old SPA still works.
+3. Then ramp or promote the dependent SPA.
+
+**Removal contract**
+
+1. Ramp SPA off the old shape to 100%.
+2. Keep API compatibility through a measured open-client retirement window.
+3. Remove the API shape in a later change.
+
+**Partial-pair rollback**
+
+1. There is no joint Cloudflare rollback across Workers.
+2. Check live counterpart compatibility before one-sided rollback.
+3. Roll one Worker only when the other remains safe; otherwise forward-fix or use coordinated sequenced rolls.
+
+### 11.5 Mitigation precedence during an incident
+
+1. Detect bad signals.
+2. If the wrong binary is serving, or the cause is unknown or mixed: mitigate with deployment controls first (hold, abort, or rollback to prior 100%), verify active deployment and probes, then close out with TTD/TTM, versions, residual risk, and opaque request IDs only.
+3. If the binary is known-good and only in-process behavior is wrong, and Flagship is wired and proven: try the safe flag default. If still bad, fall through to deployment mitigation.
+4. Never invert that order: deployment selects the binary; Flagship only reshapes behavior inside an already-serving binary.
+
+---
+
+## 12. Evidence and release-record schemas
+
+Use these field lists as conversation contracts. They are documentation schemas, not runtime Zod/Pydantic types. Never store secrets, Access bearer values, client/matter IDs, privileged URLs, or document content in these records.
+
+### 12.1 Claim evidence record
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `claim` | yes | Smallest defensible statement |
+| `classification` | yes | `platform-documented` \| `repo-observed` \| `operating-policy` \| `unverified` |
+| `source` | yes | Official URL or repository path |
+| `retrieved_on` | yes | ISO date of this review |
+| `page_updated_on` | no | When the official page shows it |
+| `exact_behavior` | yes | What the source actually says |
+| `exclusions` | yes | What it does **not** guarantee |
+| `operational_consequence` | yes | What Stage 1/2 must do differently |
+| `reverify_trigger` | yes | e.g. before coding upload job; before first SPA split |
+
+### 12.2 Immutable release / upload record
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `commit_sha` | yes | |
+| `affected_base` / `affected_head` | yes | Fail closed if unresolved |
+| `affected_packages` | yes | As Turbo reported |
+| `selected_deployables` | yes | Subset actually uploaded |
+| `widen_reason` | when widened | Explicit; never silent narrow |
+| `actual_worker_name` | yes | e.g. `front-app-production` |
+| `version_id` | yes | Cloudflare version identity |
+| `build_inputs` | yes | Enough to reproduce; include SPA `VITE_API_BASE_URL` |
+| `previous_active_deployment` | yes | Before any mutation |
+| `smoke_method` | yes | `protected_preview` \| `zero_pct_override` \| `staging` \| `skipped_with_reason` |
+| `served_version_verified` | when smoked | Fail closed if false |
+| `operator` | before promote | Single human |
+| `decision` | yes | `leave_inactive` \| `promote_100` \| `abort_restore` \| `start_split` |
+| `post_active_deployment` | after mutation | Verify before closing |
+
+### 12.3 Stage 2 ramp step record
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `worker` | yes | Actual name |
+| `old_version_id` / `new_version_id` | yes | |
+| `percent_new` | yes | |
+| `affinity_proven` | for `front-app` | First HTML through assets |
+| `bake_minutes` | yes | Declared before step |
+| `min_sample` | yes | Declared before step |
+| `signals_checked` | yes | Runtime, HTTP 5xx, named latency, asset 404 |
+| `decision` | yes | `hold` \| `advance` \| `complete` \| `rollback` |
+| `counterpart_worker_state` | yes | Other app’s live version / compatibility note |
+
+### 12.4 Incident closure record
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `request_ids_only` | yes | Opaque IDs; no matter/client identifiers |
+| `detected_at` / `mitigated_at` | yes | For TTD/TTM against internal objectives |
+| `mitigation_type` | yes | `deployment_rollback` \| `hold` \| `flagship_default` \| `forward_fix` |
+| `versions_before_after` | yes | Per actual Worker |
+| `residual_risk` | yes | Open clients, partial pair, blocked rollback, etc. |
+| `follow_ups` | yes | Signal gaps, affinity gaps, contract debt |
+
+---
+
+## 13. Cursor conversation starters
+
+Copy one block into a new agent chat after `@`-attaching the three Stage 1–2 docs (and this guide).
+
+### Implement Stage 1 upload path (docs/process first)
+
+```text
+Using the Stage 1–2 CD docs and implementation evidence guide, propose the smallest
+Stage 1 upload≠promote design for worker-api and front-app.
+Constraints: no Stage 3+; no CI YAML or Wrangler edits until I approve; affected-only
+fail-closed; CI upload principal is deployment-capable so promotion needs a broker
+CI cannot invoke; classify every Cloudflare claim and reverify via official docs MCP.
+Return: work-package checklist mapped to design §E, evidence fields you will collect,
+and open blockers.
+```
+
+### Reverify one platform claim before coding
+
+```text
+Reverify this claim against current Cloudflare docs (Documentation MCP + /index.md):
+"<paste claim>".
+Classify it, quote the exact limitation, state the operational consequence for our
+Stage 1–2 model, and say whether the operating-model/design/evidence docs need an
+edit. Do not invent CI or app code.
+```
+
+### Design Stage 2 SPA affinity without implementing
+
+```text
+Stage 2 is blocked for front-app on workers.dev. Using the evidence guide diagrams and
+static-assets gradual-rollouts docs, specify the zone/affinity/override-strip/asset-404
+acceptance tests we must pass before a non-zero SPA split. No Wrangler or app patches yet.
+```
+
+### Incident / runbook dry-run
+
+```text
+Dry-run the design runbooks for: partial promote of front-app while worker-api is fine,
+asset 404s during a split, and blocked rollback.
+Use mitigation-precedence: deployment first, Flagship only if wired.
+Produce the incident-closure schema fields you would fill—no privileged identifiers.
+```
+
+### Contract change across both apps
+
+```text
+For an additive DTO change in @repo/dtos-common consumed by both apps, walk the
+upload, smoke, promote-order, and rollback-pair rules from the operating model and
+evidence schemas. Call out what is coordinated vs what is still per-Worker and non-atomic.
+```
+
+---
+
+## 14. Agent anti-patterns
+
+Do **not**:
+
+- Treat upload, 0% deployment, Stage 1 100% promote, and Stage 2 non-zero split as interchangeable
+- Claim multi-Worker atomic deploy/rollback
+- Collapse “100 uploads” and “100 published” selection windows
+- Use preview success as proof of zone controls, Logs, or production traffic safety
+- Trust overrides without verifying the served version
+- Leave untrusted override/affinity headers intact during any two-version deployment
+- Put Flagship, browser tokens, or cached bootstrap flags in the SPA critical path for authorization
+- Log or key on client/matter identifiers while “debugging CD”
+- Write CI YAML / Wrangler / app code from a docs-only request
+- Quietly edit decision docs to match an unverified implementation convenience
+- Commit empty repo-root files created by accidental Mermaid/tooling side effects — delete them before `git add`
+
+---
+
+## 15. Compact JSON shapes for chat handoff
+
+When an agent must pass structured state to the next turn or to a human, use these shapes (still documentation contracts, not runtime validators).
+
+### Upload / promote handoff
+
+```json
+{
+  "commit_sha": "",
+  "affected_base": "",
+  "affected_head": "",
+  "affected_packages": [],
+  "selected_deployables": ["worker-api", "front-app"],
+  "widen_reason": null,
+  "workers": [
+    {
+      "actual_worker_name": "worker-api-production",
+      "version_id": "",
+      "previous_active_deployment": "",
+      "spa_api_origin": null,
+      "smoke_method": "protected_preview",
+      "served_version_verified": false,
+      "decision": "leave_inactive"
+    }
+  ]
+}
+```
+
+### Stage 2 step handoff
+
+```json
+{
+  "actual_worker_name": "front-app-production",
+  "old_version_id": "",
+  "new_version_id": "",
+  "percent_new": 0,
+  "affinity_proven": false,
+  "bake_minutes": 0,
+  "min_sample": 0,
+  "signals_ok": {
+    "runtime": false,
+    "http_5xx": false,
+    "named_latency": false,
+    "asset_404": false
+  },
+  "counterpart_note": "",
+  "decision": "hold"
+}
+```
+
+Valid `decision` values for upload/promote: `leave_inactive` | `promote_100` | `abort_restore` | `start_split`.
+Valid Stage 2 `decision` values: `hold` | `advance` | `complete` | `rollback`.

--- a/docs/cd-stage1-2-implementation-evidence.md
+++ b/docs/cd-stage1-2-implementation-evidence.md
@@ -1,0 +1,226 @@
+# Stage 1–2 CD Implementation Evidence
+
+> Agent-facing evidence pack for implementing [cd-operating-model.md](./cd-operating-model.md) and [cd-stage1-2-design.md](./cd-stage1-2-design.md). This is not a third decision document: the architectural assessment and operating model remain authoritative.
+
+**Scope:** Stage 1 version delivery and Stage 2 manual progressive exposure for `worker-api` and `front-app` only. No CI YAML, Wrangler configuration, or application implementation is prescribed here.
+
+**Last evidence review:** 2026-08-08. Cloudflare behavior changes; reverify every platform claim immediately before implementation. During the original review, Context7 was quota-blocked, so no conclusion depends on Context7 output. Official Cloudflare Documentation MCP results and direct official pages were used.
+
+---
+
+## 1. Source hierarchy
+
+1. [continuous-deployment-workers.md](./continuous-deployment-workers.md) — architectural source of truth.
+2. [cd-operating-model.md](./cd-operating-model.md) — Stage 1–2 decisions, gates, and ownership model.
+3. [cd-stage1-2-design.md](./cd-stage1-2-design.md) — operator flows, failure modes, and runbooks.
+4. This guide — evidence, repository observations, research procedure, and implementation acceptance evidence.
+5. Current official Cloudflare documentation — factual authority for platform behavior. If it changed, update the affected docs together rather than preserving a stale local claim.
+
+Classify every claim as **platform-documented**, **repo-observed**, **operating policy**, or **unverified**. Never convert an operating target, such as TTD ≤ 5 minutes, into a claimed Cloudflare SLA.
+
+---
+
+## 2. Platform evidence ledger
+
+### Versions, deployments, and triggers
+
+- A version captures bundled code, static assets, bindings, and compatibility settings—not storage state. Record a version ID as artifact identity, never as an environment snapshot. Source: [Versions & deployments](https://developers.cloudflare.com/workers/versions-and-deployments/).
+- `wrangler deploy` creates a version and immediately deploys it to 100%; `wrangler versions upload` creates a version without changing the active deployment. Stage 1 needs separate upload and human-promotion paths. Source: [Deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/).
+- The first upload cannot use `versions upload`. Bootstrap before production routes/domains or user traffic attach; keep bootstrap out of the recurring merge flow. Source: [First upload](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/#first-upload).
+- A deployment serves one version at 100%, or two versions during a split. There is no three-version canary. Finish or roll back one split before introducing another version. Source: [Versions & deployments](https://developers.cloudflare.com/workers/versions-and-deployments/).
+- Deployments can select the 100 most recent uploads; rollback can select the 100 most recently published versions. Do not collapse these into “the last 100 versions.” Sources: [deployment limits](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/#limits), [rollback limits](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/#limits).
+- Routes, domains, and cron triggers are not applied by `versions upload`. They need separate change control. Source: [Upload a version](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/#upload-a-version-without-deploying).
+- Wrangler named environments create separate suffixed Workers. Release records and overrides use actual names such as `worker-api-production`, not only package names. Source: [Wrangler environments](https://developers.cloudflare.com/workers/wrangler/environments/).
+
+### Gradual deployment and affinity
+
+- Without affinity, each request independently routes according to configured percentages. Percentages are probabilities, not exact cohort sizes, request counts, regions, or ordering. Source: [Gradual deployments](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/).
+- `Cloudflare-Workers-Version-Key` is hashed to select a version; assignments remain monotonic as the new-version percentage increases. Operators do not select a key’s version. Source: [Version affinity](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/).
+- HTML and content-hashed assets can route to different versions and 404 without affinity. `front-app` cannot split until first-request-through-assets affinity and asset-404 visibility are proven. Source: [Static assets](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/#static-assets).
+- A cookie created by the first response cannot pin the first randomly routed request. The affinity key must pre-exist the first HTML request. Source: [Anonymous applications](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/#anonymous-or-cookieless-applications).
+- Transform Rules require a route on a controlled zone and are unavailable on `workers.dev`. The current `front-app` posture therefore blocks Stage 2. Source: [Choose a version key](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/#choose-a-version-key).
+- The affinity header contributes to Workers cache partitioning. Use a dedicated random rollout value—never an auth token, user/client/matter identifier, filename, or privileged value. Source: [Workers cache keys](https://developers.cloudflare.com/workers/cache/cache-keys/).
+
+### Preview URLs and version overrides
+
+- Enabled preview URLs are public unless Cloudflare Access protects them. A production-bound preview is a production exposure surface. Source: [Manage preview access](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/#manage-access-to-preview-urls).
+- Preview URLs have no Workers Logs, `wrangler tail`, or Logpush and do not exercise zone-level controls. Preview smoke proves boot/shell only. Source: [Preview limitations](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/#limitations).
+- `preview_urls` defaults to `workers_dev`; current documented behavior enables both when neither is configured. Omission is not a deny. Source: [Preview toggle](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/#toggle-preview-urls-enable-or-disable).
+- An override applies only when its version is in the current two-version deployment; a new version may be assigned 0%. A 0% smoke is a deployment mutation, not upload. Source: [Override smoke](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/#smoke-test-example).
+- Invalid, unavailable, or not-yet-propagated overrides fall back to percentage routing; recent changes can take up to a couple of seconds to become globally available. The smoke runner must verify the served version and fail closed. Source: [Verify overrides](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/#verify-that-version-overrides-were-applied).
+- External requests can supply the override header. Derived control: block/remove untrusted overrides throughout every two-version deployment, or a caller with a version ID can bypass percentage containment. Source: [Version overrides](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/).
+
+### Rollback
+
+- Rollback creates a new single-version deployment at 100%; from a split it replaces both versions. Verify the active deployment before declaring mitigation. Source: [Rollbacks](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/).
+- Connected resources and stored data are not rewound. Never describe rollback as restoring storage, secret contents, triggers, routes, DNS, or external configuration. Source: [Rollback bindings](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/#bindings).
+- Missing resource targets and Durable Object lifecycle changes can block rollback. The runbook needs a compatible forward-fix path.
+- Deployments are per Worker; no official multi-Worker transaction was found. `worker-api` and `front-app` promotion/rollback are ordered and independently verified.
+
+### Observability
+
+- Invocation errors are runtime outcomes, not HTTP status codes. A successful invocation can return application 5xx. Stage 2 needs both signals. Source: [Invocation statuses](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/#invocation-statuses).
+- Wall time includes I/O and `waitUntil`; it is not final-byte response latency. Name every performance signal by what it measures. Source: [Metrics and analytics](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/).
+- Sampled/aggregated quantiles and recent-minute lag require a declared bake and sample count. Delayed or insufficient evidence means hold.
+- Version identity is available through Logpush `ScriptVersion` and the version metadata binding. Verify actual dashboard/export dimensions; do not assume every default chart can gate by version. Sources: [Gradual observability](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/#observability), [version metadata](https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata/).
+- Cloudflare recommends Analytics Engine or Logpush for asset-404 monitoring. Treat this as an explicit Stage 2 prerequisite. Source: [Affinity testing](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/#testing).
+
+### Flagship
+
+- The Workers binding handles authentication and avoids app-managed API tokens. Evaluate at `worker-api`; send only bounded, advisory UI decisions to `front-app`. Source: [Flagship best practices](https://developers.cloudflare.com/flagship/best-practices/).
+- The browser client provider exposes a Cloudflare API token and is not recommended for public apps. Never put it in `front-app`. Source: [Client provider](https://developers.cloudflare.com/flagship/sdk/client-provider/).
+- Typed methods use the caller fallback for known failures/type mismatch; unexpected runtime failures can throw. Catch them into the same safe behavior. Source: [Binding methods](https://developers.cloudflare.com/flagship/binding/methods/).
+- Disabling a flag serves its configured default variant. That variant and the call-site fallback are separate controls; both must be safe. Source: [Flagship concepts](https://developers.cloudflare.com/flagship/concepts/).
+- Changes can take up to 30 seconds to reflect globally. A saved kill-switch is not instant mitigation. Source: [Flag propagation](https://developers.cloudflare.com/flagship/concepts/#flag-propagation).
+- Rollout is sticky only with a stable bucketing attribute; without one, evaluations can be random. Use a dedicated opaque rollout key, never client/matter data. Source: [Percentage rollouts](https://developers.cloudflare.com/flagship/targeting/percentage-rollouts/).
+- Flagship entered public beta in May 2026. No product-specific SLA was located during this review. Treat the SLA as unverified and keep Flagship non-load-bearing unless risk/fallback is accepted. Source: [Public beta](https://developers.cloudflare.com/changelog/post/2026-05-26-public-beta/).
+
+---
+
+## 3. Repository reality map
+
+- **CI:** [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) verifies boundaries, lint, format, affected typecheck/build; it has no upload/promote job. Full history supports affected correctness. Stage 1 automation is target state.
+- **Deploy scripts:** both app package files use `wrangler deploy --env production`, so current deploy is upload plus immediate 100%.
+- **Turbo:** [`turbo.json`](../turbo.json) models affected builds; `front-app#deploy` depends on its build. Use the affected **build** graph to select uploads.
+- **Shared contracts:** both apps depend directly on `@repo/dtos-common` and `@repo/enums-common`. Shared-wire changes normally upload both consumers from one commit. Types do not prove runtime compatibility.
+- **Production resources:** named production environments resolve to `worker-api-production` and `front-app-production`; verify remote names before acting.
+- **`front-app`:** [`apps/front-app/wrangler.jsonc`](../apps/front-app/wrangler.jsonc) is assets-only with `workers_dev: true`, `preview_urls: false`, and SPA fallback. Transform Rule affinity needs a zone route/custom domain.
+- **`worker-api`:** [`apps/worker-api/wrangler.jsonc`](../apps/worker-api/wrangler.jsonc) leaves `workers_dev` and `preview_urls` unset. Current documented defaults enable both; explicitly disable preview or verify Access and remote state.
+- **SPA/API coupling:** [`apps/front-app/vite.config.ts`](../apps/front-app/vite.config.ts) bakes `VITE_API_BASE_URL`; assets are immutable while HTML revalidates. Record the API origin with every SPA version. Open clients outlive a 100% SPA promote.
+- **Smoke route:** only `GET /api/v1/health` exists. Do not document `/ready` until implemented.
+- **Correlation:** the API creates/exposes an opaque request ID; the SPA does not propagate one end to end. Correlation is a Stage 2 prerequisite, not current capability.
+- **Stateful products:** no KV/R2/DO/D1/Queue bindings exist. Their migration playbooks remain out of scope.
+- **Flagship:** no binding or evaluation path exists. Runbooks must work without a flag kill-switch.
+- **Tests/signals:** no contract test suite, version-attributed application-5xx gate, or asset-404 alert exists. Stage 2 is closed.
+
+---
+
+## 4. Implementation order and acceptance evidence
+
+### Stage 1
+
+1. **Inventory/bootstrap:** confirm actual Worker names, previous publication, routes/domains, and active deployments. Evidence: names, current version/deployment, bootstrap status.
+2. **Credential/authority boundary:** Cloudflare documents generic `Workers Scripts Write`, not upload-only authorization. Treat CI as deployment-capable until a narrower permission is verified. Evidence: principal inventory, dated permission source, approval/broker path CI cannot invoke, revocation owner, audit source—never token values.
+3. **Affected selection:** record base/head and fail closed on an unresolved comparison. Explicit widening to both apps is safe; silent narrowing is not. Evidence: SHAs, affected packages, selected deployables, build result, widening reason.
+4. **Immutable release record:** record commit, actual Worker, version ID/tag, build inputs, SPA API origin, and previous deployment. Exclude credentials, preview bearer values, client/matter IDs, and privileged content.
+5. **Protected smoke:** use Access-protected preview for boot/shell, or trusted 0%-override smoke for zone behavior. Block untrusted overrides throughout the two-version deployment and verify the served version. Evidence: method, version, synthetic probes, result, and restoration after abort.
+6. **Manual promote/rollback drill:** re-read active state before mutation; one operator and one in-flight change per Worker. Evidence: before/after deployments, authority, probes, TTD/TTM, compatible rollback target, and external state not restored.
+7. **Contract gate:** for shared wire changes, prove old/new producer-consumer combinations. Additive API support reaches 100% before the dependent SPA. Removal waits for measured open-client retirement.
+
+### Stage 2 entry gate
+
+Stage 2 remains closed until:
+
+1. `front-app` runs on a controlled zone route/custom domain.
+2. A non-privileged affinity key exists before first HTML and persists through asset requests.
+3. Untrusted affinity/override headers are overwritten or blocked.
+4. Version-attributed runtime failures, HTTP 5xx, accurately named performance signals, and asset 404s exist.
+5. End-to-end opaque request correlation is verified.
+6. Bake, sample, advance, and rollback thresholds are declared per ramp.
+7. Additive API-first and removal API-last/open-client-retirement order is rehearsed.
+8. Partial promote, wrong-version, delayed-metrics, asset-404, and blocked-rollback drills pass.
+
+No fixed 10→50→100 ladder is authoritative. Choose percentages from traffic volume and risk; insufficient evidence means hold.
+
+---
+
+## 5. Research procedure for future agents
+
+### Official-source retrieval
+
+1. Discover the current Cloudflare Documentation MCP schema before calling it.
+2. Search one platform concept per query. High-value query themes:
+   - Workers versions/deployments, upload separation, first upload, and limits.
+   - Two-version gradual traffic, affinity, first-request cookie behavior, and static assets.
+   - Preview publicity/Access/log limitations/defaults and override fallback/propagation.
+   - Rollback resource/data constraints and Durable Object lifecycle.
+   - Invocation versus HTTP status, wall time, version metadata, and `ScriptVersion`.
+   - Version/create-deployment API permissions and `Workers Scripts Write`.
+   - Flagship binding defaults/errors, disabled variant, propagation, rollout bucketing, browser token, beta/SLA.
+3. Use Context7 independently: resolve the official Cloudflare Workers project ID first, then query one concept at a time. If unavailable or quota-blocked, record it; an attempted call is not corroboration.
+4. Fetch the official page Markdown form ending in `/index.md` when semantic search returns only a partial chunk or changelog.
+5. Record URL, page update date when shown, retrieval date, exact claim, limitations, and operational consequence.
+6. Prefer current reference pages over announcements. Use changelogs for dated status facts such as public beta.
+
+### Repository verification
+
+Inspect the CI workflow, root package/Turbo files, both apps’ package/Turbo/Wrangler files, `front-app` Vite config, the health route, SPA fetch utility, and app package dependencies.
+
+Do not infer remote Cloudflare state from local omission. Verify remote names, routes, preview/Access posture, active deployments, connected resources, and permissions through an authorized read-only source.
+
+### Claim discipline
+
+Use the smallest defensible statement:
+
+- “Per-request probability,” not “exactly 10% of users.”
+- “Per-Worker ordered operations,” not “coordinated atomic deployment.”
+- “Up to a couple of seconds is documented for recent override availability,” not “instant global deployment.”
+- “Known Flagship failures use fallback; unexpected failures may throw,” not “Flagship always fails safe.”
+- “Invocation success,” not “HTTP success.”
+- “Rollback selects a prior binary/config version,” not “rollback restores production.”
+- “No upload-only permission was documented,” not “the CI token cannot deploy.”
+
+For each nontrivial claim, record: classification, source URL or repository path, observation date, exact behavior, exclusions, operational consequence, and reverification trigger.
+
+Never put production tokens, client/matter identifiers, request bodies, document names/content, or privileged URLs into evidence records or MCP queries.
+
+---
+
+## 6. Explicit uncertainties
+
+Do not claim these without new official evidence:
+
+- Atomic promotion, ordering, or rollback across `worker-api` and `front-app`.
+- A bounded zero-time global Worker deployment or rollback.
+- Exact cohort size at low traffic or region-by-region rollout.
+- Preview isolation from production bindings/resources.
+- Automatic version attribution for every dashboard metric or alert.
+- Application HTTP success from a successful Worker invocation.
+- Storage, secret, trigger, route, DNS, or connected-resource restoration on rollback.
+- Upload-only authorization from a generic Worker-write CI credential.
+- A Flagship public-beta SLA or instant global kill.
+- Safety of a browser-cached flag for authorization or privileged operations.
+
+If a required fact remains uncertain, block the stage or add a control that does not depend on the claim.
+
+---
+
+## 7. Implementation blockers
+
+1. Named deployable owner/on-call rota for both apps.
+2. Named contract owner for shared DTOs/enums.
+3. Verified remote names, active deployments, routes/domains, preview status, and Access policy.
+4. Promotion authority CI cannot invoke, or explicit acceptance/monitoring of CI deployment authority.
+5. Contract compatibility evidence for shared wire changes.
+6. Protected smoke with served-version verification and override-header control.
+7. Zone route/custom domain plus first-request SPA affinity.
+8. Version-attributed runtime, HTTP, performance, and asset-404 signals.
+9. End-to-end opaque request correlation.
+10. Ramp bake/sample/advance/rollback thresholds and incident owner.
+11. Client-retirement measurement before API contract removal.
+12. Flagship beta/fallback acceptance, bounded SPA bootstrap freshness, and server-side enforcement if it becomes load-bearing.
+
+A planned implementation is not completion. Stage exit criteria remain unchecked until evidence is real.
+
+---
+
+## 8. Official source index
+
+- [Versions & deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
+- [Deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)
+- [Gradual deployments](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/)
+- [Version affinity](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/)
+- [Version overrides](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/)
+- [Preview URLs](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)
+- [Rollbacks](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/)
+- [Wrangler environments](https://developers.cloudflare.com/workers/wrangler/environments/)
+- [Workers metrics](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/)
+- [Version metadata](https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata/)
+- [Workers cache keys](https://developers.cloudflare.com/workers/cache/cache-keys/)
+- [API token permissions](https://developers.cloudflare.com/fundamentals/api/reference/permissions/)
+- [Flagship](https://developers.cloudflare.com/flagship/)
+- [Flagship concepts](https://developers.cloudflare.com/flagship/concepts/)
+- [Flagship binding methods](https://developers.cloudflare.com/flagship/binding/methods/)
+- [Flagship percentage rollouts](https://developers.cloudflare.com/flagship/targeting/percentage-rollouts/)
+- [Flagship client provider](https://developers.cloudflare.com/flagship/sdk/client-provider/)
+- [Flagship public beta](https://developers.cloudflare.com/changelog/post/2026-05-26-public-beta/)

--- a/docs/continuous-deployment-workers.md
+++ b/docs/continuous-deployment-workers.md
@@ -389,7 +389,7 @@ flowchart LR
 
 ### Is deploy-on-every-merge realistic here?
 
-**Yes, as a staged operating model—especially while the system stays mostly stateless.** Cloudflare’s versions, gradual deployments, affinity, overrides, rollbacks (100 versions), per-version metrics, and **Flagship** (deploy≠release at the edge) are sufficient platform primitives. Your monorepo boundaries and thin current surface make this *easier* than for a mature multi-Worker stateful system. It becomes **conditionally realistic** as you add DO/Queues/DB: full CD remains right for *routine* compute changes; migrations and contract removals must stay gated.
+**Yes, as a staged operating model—especially while the system stays mostly stateless.** Cloudflare’s versions, gradual deployments, affinity, overrides, rollbacks (among the 100 most recently published versions; deployments separately select among the 100 most recent uploads), per-version metrics, and **Flagship** (deploy≠release at the edge) are sufficient platform primitives. Your monorepo boundaries and thin current surface make this *easier* than for a mature multi-Worker stateful system. It becomes **conditionally realistic** as you add DO/Queues/DB: full CD remains right for *routine* compute changes; migrations and contract removals must stay gated.
 
 ### Biggest risks
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Correct Worker version, deployment, preview, override, affinity, and rollback semantics against current Cloudflare documentation
- Make affected-only multi-app promotion ordering and rollback decisions explicit without claiming atomicity
- Harden Stage 1/2 observability, Flagship, legal-data, credential-boundary, and incident-response guardrails
- Add an agent-facing implementation evidence guide with platform ledger, repo reality map, acceptance crosswalk, research procedure, uncertainties, staged blockers, official sources, vocabulary, state tables, release/incident schemas, JSON handoff shapes, and Cursor conversation starters

## Scope
Documentation only under `docs/` (`cd-operating-model`, `cd-stage1-2-design`, `cd-stage1-2-implementation-evidence`, and a precise rollback-window fix in `continuous-deployment-workers`).

## How to use the evidence guide in the next Cursor chat
1. `@docs/cd-operating-model.md`
2. `@docs/cd-stage1-2-design.md`
3. `@docs/cd-stage1-2-implementation-evidence.md`
4. Copy a starter from §13 of the evidence guide

## Validation
- `pnpm run ci` passed
- Accidental Mermaid/tooling empty files at repo root were deleted and not committed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe096-bab6-780d-8b7c-403357807b0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe096-bab6-780d-8b7c-403357807b0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

