### PR TITLE
refactor(worker-api): extract CORS/CSRF into middlewares/

### DIFF
--- a/.claude/rules/backend/hono-gateway.md
+++ b/.claude/rules/backend/hono-gateway.md
@@ -70,7 +70,7 @@ Register in this order. The onion model runs "before" logic top-down and "after"
 ## Typing & structure
 
 - Type the app **inline** with the Hono generic - `new Hono<{ Bindings: WorkerApiBindings; Variables: RequestIdVariables }>()` (the Cloudflare / Hono pattern; neither recommends a separate env-type file). Reuse a local `type AppEnv` alias for sub-apps in the **same file** rather than repeating the generic; promote the env type to its own module only once several route files import it.
-- Keep small custom middleware inline in `index.ts`. Extract to `src/middleware/<name>.ts` (`createMiddleware<AppEnv>`, `hono/factory`) only when it grows or is reused across workers.
+- Keep small custom middleware inline in `index.ts`. Extract to `src/middlewares/<name>.ts` (`createMiddleware<AppEnv>`, `hono/factory`) only when it grows or is reused across workers.
 - Broad-with-carve-outs scoping: prefer `except` / `some` / `every` from `hono/combine` over duplicating `app.use()` per sub-route.
 - `hono/context-storage` (`getContext()`) is available (Node.js compatibility is on via compatibility_date 2026-08-04 or later) for deep call stacks, but a thin gateway should pass `c` explicitly - don't reach for it by default.
 

--- a/.cursor/rules/backend/hono-gateway.mdc
+++ b/.cursor/rules/backend/hono-gateway.mdc
@@ -70,7 +70,7 @@ Register in this order. The onion model runs "before" logic top-down and "after"
 ## Typing & structure
 
 - Type the app **inline** with the Hono generic - `new Hono<{ Bindings: WorkerApiBindings; Variables: RequestIdVariables }>()` (the Cloudflare / Hono pattern; neither recommends a separate env-type file). Reuse a local `type AppEnv` alias for sub-apps in the **same file** rather than repeating the generic; promote the env type to its own module only once several route files import it.
-- Keep small custom middleware inline in `index.ts`. Extract to `src/middleware/<name>.ts` (`createMiddleware<AppEnv>`, `hono/factory`) only when it grows or is reused across workers.
+- Keep small custom middleware inline in `index.ts`. Extract to `src/middlewares/<name>.ts` (`createMiddleware<AppEnv>`, `hono/factory`) only when it grows or is reused across workers.
 - Broad-with-carve-outs scoping: prefer `except` / `some` / `every` from `hono/combine` over duplicating `app.use()` per sub-route.
 - `hono/context-storage` (`getContext()`) is available (Node.js compatibility is on via compatibility_date 2026-08-04 or later) for deep call stacks, but a thin gateway should pass `c` explicitly - don't reach for it by default.
 

--- a/apps/worker-api/AGENTS.md
+++ b/apps/worker-api/AGENTS.md
@@ -11,9 +11,10 @@ Starter surface: `GET /api/v1/health`. Hono lifecycle, middleware order, and val
 ```
 apps/worker-api/
 ├── src/
+│   ├── middlewares/          # cors, csrf (env-dependent Hono wrappers)
 │   ├── routes/<feature>.ts   # One route module per feature
 │   ├── utils/                # opaque-request-id
-│   └── index.ts              # Middleware stack + route mounts
+│   └── index.ts              # Middleware registration + route mounts
 ├── tests/                    # Vitest suites - Cloudflare pool / workerd
 │   ├── env.d.ts              # ProvidedEnv extends Env
 │   └── tsconfig.json         # @cloudflare/vitest-pool-workers/types; in check-types
@@ -29,7 +30,7 @@ Create `src/enums/` when the first worker-local `as const` value set is needed. 
 | Task | Location |
 |------|---------|
 | New endpoint | `src/routes/<feature>.ts` then mount in `src/index.ts` |
-| Middleware | `src/index.ts` before route mounts |
+| Middleware | `src/middlewares/<name>.ts` then register in `src/index.ts` before route mounts |
 | Shared schema | `packages/dtos-common/src/api/<feature>.ts` |
 | Worker-local value set | `src/enums/` - create the directory on first use |
 | Non-trivial handler logic | `src/services/<feature>.ts` - create on first use |

--- a/apps/worker-api/src/index.ts
+++ b/apps/worker-api/src/index.ts
@@ -1,15 +1,6 @@
 import type { RequestIdVariables } from "hono/request-id";
-import {
-  CORS_ALLOWED_HEADERS,
-  CORS_ALLOWED_HTTP_METHODS,
-  HttpMethod,
-  isUnsafeHttpMethod,
-  parseHttpMethod,
-} from "@repo/enums-common";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import { cors } from "hono/cors";
-import { csrf } from "hono/csrf";
 import { HTTPException } from "hono/http-exception";
 import { methodNotAllowed } from "hono/method-not-allowed";
 import { prettyJSON } from "hono/pretty-json";
@@ -17,6 +8,8 @@ import { requestId } from "hono/request-id";
 import { secureHeaders } from "hono/secure-headers";
 import { timeout } from "hono/timeout";
 import { timing } from "hono/timing";
+import { corsMiddleware } from "./middlewares/cors";
+import { csrfMiddleware } from "./middlewares/csrf";
 import healthRoute from "./routes/health";
 import { resolveOpaqueRequestId } from "./utils/opaque-request-id";
 
@@ -62,77 +55,8 @@ app.use(
   }),
 );
 
-const CORS_ALLOW_HEADERS: string[] = [...CORS_ALLOWED_HEADERS];
-const CORS_ALLOW_METHODS: string[] = [...CORS_ALLOWED_HTTP_METHODS];
-const CORS_EXPOSE_HEADERS: string[] = ["X-Request-Id", "X-Worker-Version-Id"];
-
-/** `null` means permissive mode (any origin). */
-function parseCorsOrigins(value: string | undefined): string[] | null {
-  if (value === undefined || value.trim() === "") {
-    return null;
-  }
-  const origins = value
-    .split(",")
-    .map((origin) => origin.trim())
-    .filter(Boolean);
-  return origins.length > 0 ? origins : null;
-}
-
-type CorsMiddlewareStack = {
-  originsKey: string;
-  cors: ReturnType<typeof cors>;
-  csrf: ReturnType<typeof csrf>;
-};
-
-let corsMiddlewareStack: CorsMiddlewareStack | null = null;
-
-/**
- * Env is per-request on Workers; cache the cors/csrf factories for the current
- * CORS_ORIGINS string within this isolate.
- */
-function getCorsMiddlewareStack(
-  originsEnv: string | undefined,
-): CorsMiddlewareStack {
-  const originsKey = originsEnv ?? "";
-  if (corsMiddlewareStack?.originsKey === originsKey) {
-    return corsMiddlewareStack;
-  }
-
-  const allowedOrigins = parseCorsOrigins(originsEnv);
-  corsMiddlewareStack = {
-    originsKey,
-    cors: cors({
-      origin: allowedOrigins ?? "*",
-      allowHeaders: CORS_ALLOW_HEADERS,
-      allowMethods: CORS_ALLOW_METHODS,
-      exposeHeaders: CORS_EXPOSE_HEADERS,
-      maxAge: 600,
-    }),
-    csrf: csrf({
-      origin: allowedOrigins ?? (() => true),
-      secFetchSite: (value) => value === "same-origin" || value === "same-site",
-    }),
-  };
-  return corsMiddlewareStack;
-}
-
-app.use("/api/*", (c, next) => {
-  return getCorsMiddlewareStack(c.env.CORS_ORIGINS).cors(c, next);
-});
-
-// CSRF should not block CORS preflight, and only applies to unsafe methods.
-app.use("/api/*", async (c, next) => {
-  const method = parseHttpMethod(c.req.method);
-  if (
-    method === undefined ||
-    method === HttpMethod.OPTIONS ||
-    !isUnsafeHttpMethod(method)
-  ) {
-    return await next();
-  }
-
-  return getCorsMiddlewareStack(c.env.CORS_ORIGINS).csrf(c, next);
-});
+app.use("/api/*", corsMiddleware);
+app.use("/api/*", csrfMiddleware);
 
 const api = new Hono<AppEnv>();
 

--- a/apps/worker-api/src/middlewares/cors-origins.ts
+++ b/apps/worker-api/src/middlewares/cors-origins.ts
@@ -1,0 +1,11 @@
+/** `null` means permissive mode (any origin). */
+export function parseCorsOrigins(value: string | undefined): string[] | null {
+  if (value === undefined || value.trim() === "") {
+    return null;
+  }
+  const origins = value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+  return origins.length > 0 ? origins : null;
+}

--- a/apps/worker-api/src/middlewares/cors.ts
+++ b/apps/worker-api/src/middlewares/cors.ts
@@ -1,0 +1,29 @@
+import type { RequestIdVariables } from "hono/request-id";
+import {
+  CORS_ALLOWED_HEADERS,
+  CORS_ALLOWED_HTTP_METHODS,
+} from "@repo/enums-common";
+import { cors } from "hono/cors";
+import { createMiddleware } from "hono/factory";
+import { parseCorsOrigins } from "./cors-origins";
+
+type AppEnv = {
+  Bindings: Env;
+  Variables: RequestIdVariables;
+};
+
+const CORS_ALLOW_HEADERS: string[] = [...CORS_ALLOWED_HEADERS];
+const CORS_ALLOW_METHODS: string[] = [...CORS_ALLOWED_HTTP_METHODS];
+const CORS_EXPOSE_HEADERS: string[] = ["X-Request-Id", "X-Worker-Version-Id"];
+
+/** Env-dependent CORS: build hono/cors from c.env per request. */
+export const corsMiddleware = createMiddleware<AppEnv>(async (c, next) => {
+  const allowedOrigins = parseCorsOrigins(c.env.CORS_ORIGINS);
+  return cors({
+    origin: allowedOrigins ?? "*",
+    allowHeaders: CORS_ALLOW_HEADERS,
+    allowMethods: CORS_ALLOW_METHODS,
+    exposeHeaders: CORS_EXPOSE_HEADERS,
+    maxAge: 600,
+  })(c, next);
+});

--- a/apps/worker-api/src/middlewares/csrf.ts
+++ b/apps/worker-api/src/middlewares/csrf.ts
@@ -1,0 +1,35 @@
+import type { RequestIdVariables } from "hono/request-id";
+import {
+  HttpMethod,
+  isUnsafeHttpMethod,
+  parseHttpMethod,
+} from "@repo/enums-common";
+import { csrf } from "hono/csrf";
+import { createMiddleware } from "hono/factory";
+import { parseCorsOrigins } from "./cors-origins";
+
+type AppEnv = {
+  Bindings: Env;
+  Variables: RequestIdVariables;
+};
+
+/**
+ * CSRF for unsafe methods only — must not block CORS preflight. Origin
+ * allowlist mirrors CORS via `c.env.CORS_ORIGINS`.
+ */
+export const csrfMiddleware = createMiddleware<AppEnv>(async (c, next) => {
+  const method = parseHttpMethod(c.req.method);
+  if (
+    method === undefined ||
+    method === HttpMethod.OPTIONS ||
+    !isUnsafeHttpMethod(method)
+  ) {
+    return await next();
+  }
+
+  const allowedOrigins = parseCorsOrigins(c.env.CORS_ORIGINS);
+  return csrf({
+    origin: allowedOrigins ?? (() => true),
+    secFetchSite: (value) => value === "same-origin" || value === "same-site",
+  })(c, next);
+});


### PR DESCRIPTION
Move env-dependent cors/csrf wrappers out of index.ts into src/middlewares, matching Hono per-request c.env pattern and plural folder conventions.