### PR TITLE
fix(front-app): repair Vite DevTools Vitest and Rolldown docks

### DIFF
--- a/.claude/rules/frontend/vite-config.md
+++ b/.claude/rules/frontend/vite-config.md
@@ -19,6 +19,14 @@ paths:
 `devtools` → `tanstackRouter` (**before** `react`) → `react({ compiler: true })` (native Rust React Compiler via optional peer `oxc-transform-react`; no Babel pass) → `tailwindcss` → `cloudflare` → build-only (`apply: "build"`) → conditional via spread. Falsy plugins are skipped. Compiler on → less manual memoization ([react.md](react.md)).
 Do not configure `auxiliaryWorkers` on `front-*` to embed `worker-api` or other backends - HTTP-only SPA boundary.
 
+## DevTools
+
+- `DevTools()` (embedded plugin) and the top-level `devtools` config key are alternatives, not complements - enabling the key registers a *second* DevTools instance on serve and calls `start()` on build. Stay on the plugin.
+- Keep `build.rolldownOptions.devtools` set explicitly. `@vitejs/devtools` only seeds it from `DevToolsBuildIntegration`, which Vite registers when the top-level `devtools` key is enabled; that key is absent here, so without the explicit flag no build writes `node_modules/.rolldown` and the Rolldown dock stays empty (`RDDT0001`). Populate it with one `build`.
+- `embeddedVisibility: "passive"` keeps Vite's floating dock clear of TanStack's; **Shift+Alt+D** reveals it.
+- The `devframe auth code` banner is the client auth handshake, not an error. `clientAuthTokens` is readable only from the top-level key, so it stays un-pre-approved; never set `clientAuth: false` - it exposes the dev server and filesystem to any browser that can reach the port.
+- `@vitest/ui` stays a **root** devDependency: `@vitejs/devtools-vitest` probes for it at the pnpm workspace root, so an app-local install fails the Vitest dock with `VTDT0001` ([knip.md](../quality/knip.md)).
+
 ## Monorepo
 
 - `server.fs.strict: true`, `server.fs.allow: [repoRoot]` (`path.resolve(appDir, "../..")`) for `@repo/*`.

--- a/.claude/rules/quality/knip.md
+++ b/.claude/rules/quality/knip.md
@@ -28,6 +28,10 @@ Root `knip.jsonc` is intentionally comment-free; every override's rationale live
 
 - `ignoreDependencies: ["cloudflare"]` - `import ... from "cloudflare:workers"` in Workers-pool tests is a runtime protocol specifier resolving to no npm package.
 
+### Root (`"."`)
+
+- `ignoreDependencies: ["@vitest/ui"]` (both passes) - launched as a CLI by the Vite DevTools Vitest dock, never imported, and the root has no Vitest config for Knip's vitest plugin to bind to. It lives at the workspace root rather than in `apps/front-app` because `@vitejs/devtools-vitest` probes for it with `isPackageExists("@vitest/ui", { paths: [workspaceRoot] })` while `@vitejs/devtools` core probes integrations against the app `cwd`; under pnpm's isolated layout an app-local install is invisible to that probe and the dock fails with `VTDT0001`. Do not move it back.
+
 ### packages/vitest-config
 
 - `ignoreFiles: ["src/package-root.d.ts"]` - sidecar type declarations for `package-root.js`; unlike `ignore`, the file stays analyzed for exports/types/unresolved issues.

--- a/.cursor/rules/frontend/vite-config.mdc
+++ b/.cursor/rules/frontend/vite-config.mdc
@@ -20,6 +20,14 @@ globs: apps/front-*/vite.config.ts
 `devtools` → `tanstackRouter` (**before** `react`) → `react({ compiler: true })` (native Rust React Compiler via optional peer `oxc-transform-react`; no Babel pass) → `tailwindcss` → `cloudflare` → build-only (`apply: "build"`) → conditional via spread. Falsy plugins are skipped. Compiler on → less manual memoization ([react.mdc](react.mdc)).
 Do not configure `auxiliaryWorkers` on `front-*` to embed `worker-api` or other backends - HTTP-only SPA boundary.
 
+## DevTools
+
+- `DevTools()` (embedded plugin) and the top-level `devtools` config key are alternatives, not complements - enabling the key registers a *second* DevTools instance on serve and calls `start()` on build. Stay on the plugin.
+- Keep `build.rolldownOptions.devtools` set explicitly. `@vitejs/devtools` only seeds it from `DevToolsBuildIntegration`, which Vite registers when the top-level `devtools` key is enabled; that key is absent here, so without the explicit flag no build writes `node_modules/.rolldown` and the Rolldown dock stays empty (`RDDT0001`). Populate it with one `build`.
+- `embeddedVisibility: "passive"` keeps Vite's floating dock clear of TanStack's; **Shift+Alt+D** reveals it.
+- The `devframe auth code` banner is the client auth handshake, not an error. `clientAuthTokens` is readable only from the top-level key, so it stays un-pre-approved; never set `clientAuth: false` - it exposes the dev server and filesystem to any browser that can reach the port.
+- `@vitest/ui` stays a **root** devDependency: `@vitejs/devtools-vitest` probes for it at the pnpm workspace root, so an app-local install fails the Vitest dock with `VTDT0001` ([knip.md](../quality/knip.mdc)).
+
 ## Monorepo
 
 - `server.fs.strict: true`, `server.fs.allow: [repoRoot]` (`path.resolve(appDir, "../..")`) for `@repo/*`.

--- a/.cursor/rules/quality/knip.mdc
+++ b/.cursor/rules/quality/knip.mdc
@@ -28,6 +28,10 @@ Root `knip.jsonc` is intentionally comment-free; every override's rationale live
 
 - `ignoreDependencies: ["cloudflare"]` - `import ... from "cloudflare:workers"` in Workers-pool tests is a runtime protocol specifier resolving to no npm package.
 
+### Root (`"."`)
+
+- `ignoreDependencies: ["@vitest/ui"]` (both passes) - launched as a CLI by the Vite DevTools Vitest dock, never imported, and the root has no Vitest config for Knip's vitest plugin to bind to. It lives at the workspace root rather than in `apps/front-app` because `@vitejs/devtools-vitest` probes for it with `isPackageExists("@vitest/ui", { paths: [workspaceRoot] })` while `@vitejs/devtools` core probes integrations against the app `cwd`; under pnpm's isolated layout an app-local install is invisible to that probe and the dock fails with `VTDT0001`. Do not move it back.
+
 ### packages/vitest-config
 
 - `ignoreFiles: ["src/package-root.d.ts"]` - sidecar type declarations for `package-root.js`; unlike `ignore`, the file stays analyzed for exports/types/unresolved issues.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ Notes:
    ```
 2. Verify the API: `GET` `http://localhost:8700/api/v1/health`
 3. Open the frontend: `http://localhost:5174`
+4. Optional - build once so the Vite DevTools Rolldown dock has data:
+   ```sh
+   pnpm turbo run build --filter=front-app
+   ```
+   Rolldown only writes its logs to `node_modules/.rolldown` during a build, so
+   until then the dock is empty and the dev server logs `RDDT0001`. Vite's
+   DevTools dock starts hidden - press **Shift+Alt+D** to reveal it.
 
 Focused work on one package: `pnpm turbo run dev --filter=worker-api` (see [Scoping](#scoping-pnpm--turborepo)).
 

--- a/README.md
+++ b/README.md
@@ -156,13 +156,8 @@ Notes:
    ```
 2. Verify the API: `GET` `http://localhost:8700/api/v1/health`
 3. Open the frontend: `http://localhost:5174`
-4. Optional - build once so the Vite DevTools Rolldown dock has data:
-   ```sh
-   pnpm turbo run build --filter=front-app
-   ```
-   Rolldown only writes its logs to `node_modules/.rolldown` during a build, so
-   until then the dock is empty and the dev server logs `RDDT0001`. Vite's
-   DevTools dock starts hidden - press **Shift+Alt+D** to reveal it.
+4. Reveal the Vite DevTools dock with **Shift+Alt+D**. Its Rolldown panel stays
+   empty until a build has run: `pnpm turbo run build --filter=front-app`.
 
 Focused work on one package: `pnpm turbo run dev --filter=worker-api` (see [Scoping](#scoping-pnpm--turborepo)).
 

--- a/apps/front-app/AGENTS.md
+++ b/apps/front-app/AGENTS.md
@@ -76,6 +76,27 @@ Local env: `cp .env.example .env.local` (and `.env.production.example` for prod 
 | `pnpm -w check-types` | Verify route generation and typecheck the workspace |
 | `pnpm analyze` | Bundle stats (`dist/stats.html`) |
 
+### Vite DevTools
+
+`pnpm dev` mounts Vite DevTools (embedded) alongside TanStack's panel. Vite's dock
+starts hidden - reveal it with **Shift+Alt+D**.
+
+The Rolldown dock reads build logs from `node_modules/.rolldown`, which only a
+**build** writes. On a fresh clone it is empty and the server logs `RDDT0001`;
+run `pnpm -w turbo run build --filter=front-app` once to populate it. This is
+expected, not a misconfiguration.
+
+The `devframe auth code NNNNNN` banner on each restart is the DevTools client
+auth handshake, not an error. It is not pre-approved: `clientAuthTokens` is only
+readable from the top-level `devtools` config key, and enabling that key makes
+Vite register a *second* DevTools instance on serve and call `start()` on build.
+Keep the OTP; do not set `clientAuth: false` (it opens the dev server and
+filesystem to any browser that can reach the port).
+
+`@vitest/ui` is a **root** devDependency, not an app one: `@vitejs/devtools-vitest`
+probes for it at the pnpm workspace root rather than the app dir, and installing
+it app-locally makes the Vitest dock fail with `VTDT0001`. Keep it at the root.
+
 In-app absolute imports use package.json `imports` (`#/*` → `./src/*`), e.g. `import { Button } from "#/components/ui/Button"`.
 
 ## Contribution

--- a/apps/front-app/AGENTS.md
+++ b/apps/front-app/AGENTS.md
@@ -76,27 +76,6 @@ Local env: `cp .env.example .env.local` (and `.env.production.example` for prod 
 | `pnpm -w check-types` | Verify route generation and typecheck the workspace |
 | `pnpm analyze` | Bundle stats (`dist/stats.html`) |
 
-### Vite DevTools
-
-`pnpm dev` mounts Vite DevTools (embedded) alongside TanStack's panel. Vite's dock
-starts hidden - reveal it with **Shift+Alt+D**.
-
-The Rolldown dock reads build logs from `node_modules/.rolldown`, which only a
-**build** writes. On a fresh clone it is empty and the server logs `RDDT0001`;
-run `pnpm -w turbo run build --filter=front-app` once to populate it. This is
-expected, not a misconfiguration.
-
-The `devframe auth code NNNNNN` banner on each restart is the DevTools client
-auth handshake, not an error. It is not pre-approved: `clientAuthTokens` is only
-readable from the top-level `devtools` config key, and enabling that key makes
-Vite register a *second* DevTools instance on serve and call `start()` on build.
-Keep the OTP; do not set `clientAuth: false` (it opens the dev server and
-filesystem to any browser that can reach the port).
-
-`@vitest/ui` is a **root** devDependency, not an app one: `@vitejs/devtools-vitest`
-probes for it at the pnpm workspace root rather than the app dir, and installing
-it app-locally makes the Vitest dock fail with `VTDT0001`. Keep it at the root.
-
 In-app absolute imports use package.json `imports` (`#/*` → `./src/*`), e.g. `import { Button } from "#/components/ui/Button"`.
 
 ## Contribution

--- a/apps/front-app/package.json
+++ b/apps/front-app/package.json
@@ -31,7 +31,6 @@
     "@vitejs/devtools-vite": "catalog:",
     "@vitejs/devtools-vitest": "catalog:",
     "@vitejs/plugin-react": "catalog:",
-    "@vitest/ui": "catalog:",
     "oxc-transform-react": "catalog:",
     "rollup-plugin-visualizer": "catalog:",
     "tailwindcss": "catalog:",

--- a/apps/front-app/vite.config.ts
+++ b/apps/front-app/vite.config.ts
@@ -134,8 +134,6 @@ export default defineConfig(({ command, mode }) => {
 
   const plugins: PluginOption[] = [
     devtools({ consolePiping: { enabled: false } }),
-    // `passive`: Vite's floating dock stays hidden until Shift+Alt+D so it does
-    // not overlap TanStack's. Revealing once persists per-origin.
     DevTools({ embeddedVisibility: "passive" }),
     tanstackRouter({
       autoCodeSplitting: true,
@@ -187,13 +185,8 @@ export default defineConfig(({ command, mode }) => {
       reportCompressedSize: false,
       chunkSizeWarningLimit: 500,
       rolldownOptions: {
-        // Required - do not remove. `@vitejs/devtools` only seeds this
-        // (`rolldownOptions.devtools ??= {}`) from DevToolsBuildIntegration,
-        // which Vite registers solely when the top-level `devtools` config key
-        // is enabled. This app runs DevTools as a plugin instead, so that key
-        // is absent, the build integration never loads, and without this line
-        // no build writes `node_modules/.rolldown` - leaving the Rolldown dock
-        // empty with RDDT0001. Verified by diffing session dirs either way.
+        // Required: without it no build writes `node_modules/.rolldown`
+        // (see .claude/rules/frontend/vite-config.md).
         devtools: {},
         onLog(level, log, log2) {
           if (

--- a/apps/front-app/vite.config.ts
+++ b/apps/front-app/vite.config.ts
@@ -134,7 +134,9 @@ export default defineConfig(({ command, mode }) => {
 
   const plugins: PluginOption[] = [
     devtools({ consolePiping: { enabled: false } }),
-    DevTools(),
+    // `passive`: Vite's floating dock stays hidden until Shift+Alt+D so it does
+    // not overlap TanStack's. Revealing once persists per-origin.
+    DevTools({ embeddedVisibility: "passive" }),
     tanstackRouter({
       autoCodeSplitting: true,
     }),
@@ -185,6 +187,13 @@ export default defineConfig(({ command, mode }) => {
       reportCompressedSize: false,
       chunkSizeWarningLimit: 500,
       rolldownOptions: {
+        // Required - do not remove. `@vitejs/devtools` only seeds this
+        // (`rolldownOptions.devtools ??= {}`) from DevToolsBuildIntegration,
+        // which Vite registers solely when the top-level `devtools` config key
+        // is enabled. This app runs DevTools as a plugin instead, so that key
+        // is absent, the build integration never loads, and without this line
+        // no build writes `node_modules/.rolldown` - leaving the Rolldown dock
+        // empty with RDDT0001. Verified by diffing session dirs either way.
         devtools: {},
         onLog(level, log, log2) {
           if (

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -24,9 +24,7 @@
     ".": {
       // Referenced from .github/actions/**/action.yml run steps.
       "entry": [".github/actions/**/*.mjs!"],
-      // Launched as a CLI by the Vite DevTools Vitest dock, never imported.
-      // Lives at the root because `@vitejs/devtools-vitest` probes for it at
-      // the pnpm workspace root, not the app dir (see rules/quality/knip.md).
+      // Vite DevTools Vitest dock CLI; must stay at the root (rules/quality/knip.md).
       "ignoreDependencies": ["@vitest/ui"],
     },
     "packages/vitest-config": {

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -11,7 +11,6 @@
         "@vitejs/devtools-oxc!",
         "@vitejs/devtools-vite!",
         "@vitejs/devtools-vitest!",
-        "@vitest/ui!",
         "tailwindcss!",
       ],
       "project": [
@@ -25,6 +24,10 @@
     ".": {
       // Referenced from .github/actions/**/action.yml run steps.
       "entry": [".github/actions/**/*.mjs!"],
+      // Launched as a CLI by the Vite DevTools Vitest dock, never imported.
+      // Lives at the root because `@vitejs/devtools-vitest` probes for it at
+      // the pnpm workspace root, not the app dir (see rules/quality/knip.md).
+      "ignoreDependencies": ["@vitest/ui"],
     },
     "packages/vitest-config": {
       "ignoreFiles": ["src/package-root.d.ts"],

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "catalog:",
     "@changesets/cli": "catalog:",
+    "@vitest/ui": "catalog:",
     "cross-env": "catalog:",
     "eslint-plugin-better-tailwindcss": "catalog:",
     "knip": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,21 +146,24 @@ importers:
       '@changesets/cli':
         specifier: 'catalog:'
         version: 3.0.1
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.11(vitest@4.1.11)
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0
       eslint-plugin-better-tailwindcss:
         specifier: 'catalog:'
-        version: 4.7.0(oxlint@1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)))(tailwindcss@4.3.3)(typescript@7.0.2)
+        version: 4.7.0(oxlint@1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)))(tailwindcss@4.3.3)(typescript@7.0.2)
       knip:
         specifier: 'catalog:'
         version: 6.32.2
       oxfmt:
         specifier: 'catalog:'
-        version: 0.64.0(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
+        version: 0.64.0(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint:
         specifier: 'catalog:'
-        version: 1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
+        version: 1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint:
         specifier: 'catalog:'
         version: 7.0.2001
@@ -178,7 +181,7 @@ importers:
         version: 7.0.2
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
         version: 4.125.0
@@ -264,9 +267,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.1.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2))(babel-plugin-react-compiler@1.0.0)(oxc-transform-react@0.145.0)(vite@8.2.2)
-      '@vitest/ui':
-        specifier: 'catalog:'
-        version: 4.1.11(vitest@4.1.11)
       oxc-transform-react:
         specifier: 'catalog:'
         version: 0.145.0
@@ -321,7 +321,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/ui@4.1.11)(vite@8.2.2)
+        version: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
         version: 4.125.0
@@ -366,7 +366,7 @@ importers:
         version: 1.0.0(@vitest/runner@4.1.11)(@vitest/snapshot@4.1.11)(vitest@4.1.11)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/ui@4.1.11)(vite@8.2.2)
+        version: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
 packages:
 
@@ -4728,7 +4728,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 5.20260820.0-alpha
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/ui@4.1.11)(vite@8.2.2)
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       wrangler: 4.125.0
       zod: 4.4.3
     transitivePeerDependencies:
@@ -6273,7 +6273,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.5(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -6289,7 +6289,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -6376,7 +6376,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/ui@4.1.11)(vite@8.2.2)
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -6742,7 +6742,7 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  eslint-plugin-better-tailwindcss@4.7.0(oxlint@1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)))(tailwindcss@4.3.3)(typescript@7.0.2):
+  eslint-plugin-better-tailwindcss@4.7.0(oxlint@1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)))(tailwindcss@4.3.3)(typescript@7.0.2):
     dependencies:
       '@eslint/css-tree': 4.0.5
       '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@7.0.2))
@@ -6754,7 +6754,7 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       valibot: 1.4.2(typescript@7.0.2)
     optionalDependencies:
-      oxlint: 1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
     transitivePeerDependencies:
       - '@eslint/css'
       - typescript
@@ -7155,7 +7155,7 @@ snapshots:
       '@oxc-transform-react/binding-win32-ia32-msvc': 0.145.0
       '@oxc-transform-react/binding-win32-x64-msvc': 0.145.0
 
-  oxfmt@0.62.0(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
+  oxfmt@0.62.0(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -7178,9 +7178,9 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.62.0
       '@oxfmt/binding-win32-ia32-msvc': 0.62.0
       '@oxfmt/binding-win32-x64-msvc': 0.62.0
-      vite-plus: 0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
-  oxfmt@0.64.0(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
+  oxfmt@0.64.0(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -7203,7 +7203,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.64.0
       '@oxfmt/binding-win32-ia32-msvc': 0.64.0
       '@oxfmt/binding-win32-x64-msvc': 0.64.0
-      vite-plus: 0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
   oxlint-tsgolint@7.0.2001:
     optionalDependencies:
@@ -7214,7 +7214,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 7.0.2001
       '@oxlint-tsgolint/win32-x64': 7.0.2001
 
-  oxlint@1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
+  oxlint@1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.77.0
       '@oxlint/binding-android-arm64': 1.77.0
@@ -7236,9 +7236,9 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.77.0
       '@oxlint/binding-win32-x64-msvc': 1.77.0
       oxlint-tsgolint: 7.0.2001
-      vite-plus: 0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
-  oxlint@1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
+  oxlint@1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.79.0
       '@oxlint/binding-android-arm64': 1.79.0
@@ -7260,7 +7260,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.79.0
       '@oxlint/binding-win32-x64-msvc': 1.79.0
       oxlint-tsgolint: 7.0.2001
-      vite-plus: 0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
   package-manager-detector@1.8.0: {}
 
@@ -7639,7 +7639,7 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0):
+  vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.143.0
       '@oxlint/plugins': 1.73.0
@@ -7653,10 +7653,10 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       '@voidzero-dev/vite-plus-core': 0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
-      oxfmt: 0.62.0(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
+      oxfmt: 0.62.0(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.9(@types/node@26.2.0)(@vitest/ui@4.1.11)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.9
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.9
@@ -7712,7 +7712,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -7737,10 +7737,40 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
       '@vitest/browser-preview': 4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/ui': 4.1.11(vitest@4.1.11)
     transitivePeerDependencies:
       - msw
 
   vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/ui@4.1.11)(vite@8.2.2):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.2)
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.2(@types/node@26.2.0)(@vitejs/devtools@0.6.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+      '@vitest/browser-preview': 4.1.10(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/ui': 4.1.11(vitest@4.1.11)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2)


### PR DESCRIPTION
Two Vite DevTools diagnostics on `pnpm dev`:

VTDT0001 - the Vitest dock tried to auto-install `@vitest/ui` and ran `pnpm add -D` at the workspace root, which pnpm refuses (ERR_PNPM_ADDING_TO_ROOT). `@vitejs/devtools` core probes integration packages against the app `cwd` (plugins-DoobyUBH.js:124) but `@vitejs/devtools-vitest` probes and installs `@vitest/ui` against `workspaceRoot` (index.mjs:50-85). Under pnpm's isolated layout an app-local install is invisible to that probe, so it always concluded "missing" and always attempted a root install. No config option overrides either root, so move `@vitest/ui` to the root package.json; Node's directory walk keeps it resolvable from the app.

RDDT0001 - the Rolldown dock had no build logs. Kept the explicit `build.rolldownOptions.devtools` and documented why it cannot be dropped: `@vitejs/devtools` only seeds it from DevToolsBuildIntegration, which Vite registers when the top-level `devtools` config key is enabled. This app runs DevTools as a plugin, so that key is absent and no build writes `node_modules/.rolldown` without the explicit flag.

Also set `embeddedVisibility: "passive"` so Vite's floating dock stops overlapping TanStack's (Shift+Alt+D reveals it).

The DevTools auth OTP is left as-is: `clientAuthTokens` is only readable from the top-level `devtools` key, and enabling that key registers a second DevTools instance on serve and calls `start()` on build.

Verified: `pnpm run ci` green, both knip passes, dev server starts with neither diagnostic, and a build writes a new `.rolldown` session.


Claude-Session: https://claude.ai/code/session_01Yc1k6LYPLkB5Nfiq1jp8Pa