### PR TITLE
fix(release): harden the pipeline per docs-grounded audit

### DIFF
--- a/.claude/rules/ops/cd.md
+++ b/.claude/rules/ops/cd.md
@@ -19,12 +19,12 @@ Weakening a deploy gate or shipping with missing credentials is covered by [`gua
 - **There is no `push: tags:` trigger, and adding one is a regression.** The release tag is created with `GITHUB_TOKEN`, and events created by that token do not start workflow runs, so a tag trigger never fires (GitHub `GITHUB_TOKEN` docs; changesets/action#669, changesets/changesets#1545). Zero tags existed while that dead trigger was the only path.
 - Do not deploy from `pull_request` or `pull_request_target` (the latter especially - base context plus untrusted checkout is a pwn pattern).
 - **Concurrency is `cd-production`, `cancel-in-progress: false`, `queue: max`.** Cancelling would drop an in-flight ship; and with the default `queue: single` a third trigger replaces the pending one, silently losing that release.
-- **Checkout uses `ref: ${{ inputs.tag }}`** - the ship must match the tagged commit, not whatever the branch tip is at job start.
+- **Checkout uses `ref: ${{ inputs.tag }}`** - the ship must match the tagged commit, not whatever the branch tip is at job start. The tag must be exactly `vX.Y.Z`: a changesets pre-mode tag (`v1.0.0-next.0`) fails closed at `Resolve release version` instead of shipping @100%, and that red run is by design. `RELEASE_SHA` (the tagged commit) is what upload messages and Release notes record - `GITHUB_SHA` points at the dispatching ref on `workflow_dispatch` redeploys.
 
 ## Auth and environment
 
 - **The job declares `environment: {name: production, url: …}`.** Protection rules, required reviewers, and environment secrets belong there. Do not move Cloudflare credentials into unprotected repository secrets "for convenience".
-- **Cloudflare credentials are never passed in by a caller.** `on.workflow_call.secrets` declares only `TURBO_TOKEN` and `TURBO_REMOTE_CACHE_SIGNATURE_KEY`; `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are resolved from the `production` environment by the job itself. Never switch the caller to `secrets: inherit`.
+- **Cloudflare credentials are never passed in by a caller.** `on.workflow_call.secrets` declares only `TURBO_TOKEN` and `TURBO_REMOTE_CACHE_SIGNATURE_KEY`; `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are resolved from the `production` environment by the individual wrangler steps via step-level `env:` - install, build, and smoke never see them. Never switch the caller to `secrets: inherit`, and never lift the credentials back to job-level `env:`. A new wrangler step must copy the two-line credentials `env:` block - the `Require deploy inputs` gate only vouches for its own copy.
 - **Both Cloudflare values are required** - the workflow fails closed if either is empty. Use a **scoped** Workers API token (Edit Cloudflare Workers, account-scoped), never a Global API Key, never a committed value. Secrets Store Edit only if the Worker binds Secrets Store.
 - **`VITE_API_BASE_URL` is a repository/environment *variable*, not a secret** - public build-time config for `front-app`, and the `environment.url`. Still required; empty fails.
 - **Wrangler auth in CI is non-interactive** via those env vars ([Cloudflare GitHub Actions guide](https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/)). Do not add `wrangler login` to CD.
@@ -34,9 +34,9 @@ Weakening a deploy gate or shipping with missing credentials is covered by [`gua
 
 - **This repo does not use `wrangler deploy` or `cloudflare/wrangler-action` in CD.** Package scripts `upload` / `promote` call `wrangler versions upload` then `wrangler versions deploy …@100% --yes` against the workspace-pinned Wrangler, keeping the CLI identical to local and avoiding a second floating action pin.
 - **Upload is machine-readable:** `WRANGLER_OUTPUT_FILE_PATH` captures JSON lines; CD parses `type === "version-upload"` for `version_id`. Do not replace that with scraping stdout.
-- **Keep `--strict`, and tag/message with the release version + `GITHUB_SHA`.** Cloudflare: `--strict` makes upload/deploy more defensive in non-interactive CI - do not drop it to force green.
+- **Keep `--strict`, and tag/message with the release version + `RELEASE_SHA` (the tagged commit).** Cloudflare: `--strict` makes upload/deploy more defensive in non-interactive CI - do not drop it to force green.
 - **Traffic policy today is 100%.** Gradual percentages exist; do not add them without observability and a rollback runbook.
-- **`versions upload` does not apply routes, custom domains, or cron triggers** ([deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)). When those land in `wrangler.jsonc`, also run `wrangler triggers deploy --env production` (comment already in the workflow).
+- **`versions upload` does not apply routes, custom domains, or cron triggers** ([deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)). When those land in `wrangler.jsonc`, also run `wrangler triggers deploy --env production` (comment beside the upload in `upload-version.sh`).
 - **Uploads may run in `parallel:`; promotes stay sequential.** `worker-api` then `front-app` at `@100%`. If front fails after API is live, production can be split - the workflow's error names the rollback (`wrangler rollback --env production`). Do not reorder or parallelize the two promotes without handling that partial state.
 
 ## Release and deployment records
@@ -46,7 +46,7 @@ Weakening a deploy gate or shipping with missing credentials is covered by [`gua
 
 ## Same hardening as CI
 
-SHA-pinned `uses:` with `# vX.Y.Z` comments; `persist-credentials: false` on checkout; workflow `permissions: {}` with per-job re-grants (`contents: write` for the Release, `deployments: write` for the environment record); runner `ubuntu-24.04`; frozen `pnpm install`; Node `24` via `pnpm/setup`; telemetry off. Multi-line shell uses `set -euo pipefail`. `$RUNNER_TEMP` only ever from a step - see the expression-context section in [`ops/ci.md`](ci.md), which is what broke this file once. Do not diverge "just for CD".
+SHA-pinned `uses:` with `# vX.Y.Z` comments; `persist-credentials: false` on checkout; workflow `permissions: {}` with per-job re-grants (`contents: write` for the Release, `deployments: write` for the environment record); runner `ubuntu-24.04`; frozen `pnpm install`; Node `24` via `pnpm/setup`; telemetry off. Step bodies live as scripts per the convention in [`ops/ci.md`](ci.md); the promotes and the smoke curl stay inline so the deploy-order coupling stays visible in the workflow. `$RUNNER_TEMP` only ever from a step - see the expression-context section in [`ops/ci.md`](ci.md), which is what broke this file once. Do not diverge "just for CD".
 
 ## What is deliberately not used
 

--- a/.claude/rules/ops/ci.md
+++ b/.claude/rules/ops/ci.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - ".github/workflows/**"
+  - ".github/actions/**"
   - ".github/CODEOWNERS"
 ---
 
@@ -21,12 +22,13 @@ This is not hypothetical. `d3e741b` added `NODE_COMPILE_CACHE: ${{ runner.temp }
 ## Repo invariants
 
 - **Triggers:** `pull_request`, `workflow_call`, `workflow_dispatch`. **No `push:`** - pushes to `main` are covered by `release.yml`'s `gate`, so a commit is never checked twice.
-- **Parity:** root `pnpm ci` and the workflow run the same *kinds* of checks. Change both when adding or renaming a gate. Scope differs by event on purpose: `--affected` on `pull_request` only, full graph on `workflow_call` / `workflow_dispatch` (a release must validate everything). Two `if:`-gated steps express this - never interpolate the flag into a `run:` body.
+- **Parity:** root `pnpm ci` and the workflow run the same *kinds* of checks. Change both when adding or renaming a gate. Scope differs by event on purpose: `--affected` on `pull_request` only, full graph on `workflow_call` / `workflow_dispatch` (a release must validate everything). Two `if:`-gated steps express this - never interpolate the flag into a `run:` body. The dependency audit is `pull_request`-only for the inverse reason: the advisory DB changes daily, so an auditing release gate is not a pure function of the commit; local `pnpm run ci` still audits.
 - **`TURBO_SCM_BASE` is set on `pull_request` only,** to `origin/<base_ref>`; checkout only creates remote-tracking refs. It is deliberately empty elsewhere: the full-graph path needs no base, and `github.event.before` is all-zeros on a new branch, which silently degrades `--affected` to "everything changed". Keep `fetch-depth: 0` + `filter: blob:none`.
 - **Parallelization:** one job, using the GitHub Actions `parallel:` step keyword (GA 2026-06-25, alongside `background` / `wait` / `wait-all` / `cancel`) for OXC (`lint`/`format`), `boundaries`, `types:check`, `knip`, and `syncpack`. A `parallel:` list item takes **no sibling keys** - `parallel:` is its only property. A **single** `turbo run check-types test build` invocation, not two turbo CLIs; turbo schedules against default concurrency (no override in `turbo.json`). Wrangler deploy dry-run is `front-app` only after the join (`worker-api` build is already a dry-run).
 - **`changeset-release/**` is skipped** via a job-level `if` on `github.head_ref`. A `pull_request` `branches-ignore` filters the *base* branch and cannot do this. The release commit is validated by `gate` on the merge commit, so no branch-protection exemption is needed.
+- **Step bodies longer than a few lines live as scripts, not inline YAML:** workflow-invoked ones under `.github/actions/<workflow>/` (`cd/`, `release/`), composite-action ones beside their `action.yml`. Invoke with `bash <path>` and wire inputs through step-level `env:`; each script opens with `set -euo pipefail` and fails fast on missing input (`:?` guards or an explicit check). Short steps stay inline.
 - **Install:** `pnpm install --frozen-lockfile` after `pnpm/setup` with `install: false`. Node `runtime: node@24` matching root engines.
 - **Remote cache:** job env wires `TURBO_TOKEN`, `TURBO_TEAM`, and `TURBO_REMOTE_CACHE_SIGNATURE_KEY` (repo secret, >= 32 bytes, same value as local machines - `turbo.json` enables `remoteCache.signature` + `longerSignatureKey`). `workflow_call` declares those two secrets **explicitly** so the release gate never receives Cloudflare credentials; never switch that call to `secrets: inherit`.
-- **Pins:** every `uses:` is a full-length commit SHA with a `# vX.Y.Z` comment. `actions/checkout` sets `persist-credentials: false`. Workflow `permissions: {}` with per-job re-grants. Runners: `ubuntu-24.04` (not `ubuntu-latest`).
+- **Pins:** every `uses:` is a full-length commit SHA with a `# vX.Y.Z` comment. `actions/checkout` sets `persist-credentials: false`. Workflow `permissions: {}` with per-job re-grants - `contents: read` only, since artifact upload and the setup caches use the runner's runtime token, not `GITHUB_TOKEN`. Runners: `ubuntu-24.04` (not `ubuntu-latest`).
 - **`cancel-in-progress` only on pull_request.** Never interpolate `github.ref_name` into script bodies. No production/Cloudflare secrets in this workflow (CD only).
 - Do not add scanners "for completeness" without a concrete threat and owner. Telemetry stays off at workflow `env:`.

--- a/.claude/rules/ops/release.md
+++ b/.claude/rules/ops/release.md
@@ -7,7 +7,7 @@ paths:
 
 # Releases
 
-[Changesets](https://changesets.dev) computes versions; the pipeline is [`.github/workflows/release.yml`](../../../.github/workflows/release.yml). Read it for the job list. Human-facing "how do I" lives in [`.changeset/README.md`](../../../.changeset/README.md); CI internals in [`ops/ci.md`](ci.md); the deploy in [`ops/cd.md`](cd.md).
+[Changesets](https://changesets.dev) computes versions; the pipeline is [`.github/workflows/release.yml`](../../../.github/workflows/release.yml). Read it for the job list; long step bodies live as `bash`-invoked scripts under `.github/actions/` (convention: [`ops/ci.md`](ci.md)). Human-facing "how do I" lives in [`.changeset/README.md`](../../../.changeset/README.md); CI internals in [`ops/ci.md`](ci.md); the deploy in [`ops/cd.md`](cd.md).
 
 Nothing is published to npm. Every workspace is `private: true`, no `publishConfig`, no `.npmrc`. **A release is a git tag plus a Cloudflare Workers promote.**
 
@@ -24,9 +24,9 @@ push to main ──► Release  (concurrency release-main, queue: max, never can
 ## Invariants
 
 - **`gate` runs on every push to main, in both modes.** While a release PR is open the mode is always `version`, so a gate placed only on the release path would leave `main` unvalidated for that PR's whole life. Do not move it under the `mode != 'version'` branch.
-- **The tag is the idempotency key.** `create-release-tag` skips when `vX.Y.Z` exists and reports `created=false`; `deploy` is gated on `created == 'true'`, so re-running `Release` never re-deploys. To redeploy on purpose use `cd.yml`'s `workflow_dispatch` with the tag.
+- **The tag is the idempotency key.** `create-release-tag` skips when `vX.Y.Z` exists and reports `created=false`; `deploy` is gated on `created == 'true'`, so re-running `Release` never re-deploys. The existence probe is three-way: 2xx skips, 404 creates, and any other probe failure fails the job rather than guessing. To redeploy on purpose use `cd.yml`'s `workflow_dispatch` with the tag.
 - **`mode != 'version'`, not `mode == 'publish'`.** `select-mode` returns `publish` only when publishable packages exist, and all of ours are private, so `publish` is unreachable and the equality test would never fire. This condition is load-bearing.
-- **`privatePackages.tag: false` is deliberate.** `changeset tag` would emit `front-app@X.Y.Z` and `worker-api@X.Y.Z`; the deploy keys on one shared `vX.Y.Z`, which is why the tag is cut by `create-release-tag` instead.
+- **`privatePackages.tag: false` is deliberate.** `changeset git-tag` (the v3 name of `changeset tag`) would emit `front-app@X.Y.Z` and `worker-api@X.Y.Z`; the deploy keys on one shared `vX.Y.Z`, which is why the tag is cut by `create-release-tag` instead.
 - **`baseBranch: "main"` and `privatePackages.version: true` are load-bearing.** The documented defaults are `"master"` and `{version: false, tag: false}` — the latter would version nothing at all here.
 - **The version PR branch is force-pushed, not accumulated.** Every push to `main` resets `changeset-release/main` from the tip, re-runs `changeset version`, and force-pushes one commit. It can never be behind `main` or conflict with it, and manual edits to it are destroyed. Verified on PR #19: base tracked the newest `main` SHA with a single commit.
 - **Tags created with `GITHUB_TOKEN` do not trigger workflows.** This is why `cd.yml` has no `push: tags:` trigger and `release.yml` calls it directly. Do not "restore" a tag trigger; it is dead code (GitHub `GITHUB_TOKEN` docs; changesets/action#669).
@@ -41,9 +41,10 @@ push to main ──► Release  (concurrency release-main, queue: max, never can
 | `version` push rejected | Re-run; the branch is reset from `main` each time. |
 | `tag` version drift | Re-align both apps in one commit; the action fails closed. |
 | Tag already exists | `created=false`, deploy skipped. Not an error. |
-| `deploy` upload/promote/smoke | Tag stands. Re-run `cd.yml` via `workflow_dispatch` with the tag, or `pnpm --filter=<app> exec wrangler rollback --env production`. |
+| `deploy` upload/promote/smoke | Tag stands. "Re-run failed jobs" on the Release run retries the deploy (the `tag` job's `created=true` output is preserved; "re-run all jobs" instead re-probes, gets `created=false`, and skips - safe, not a retry), or run `cd.yml` via `workflow_dispatch` with the tag. Rollback: `pnpm --filter=<app> exec wrangler rollback --env production`. |
 
 ## Repo settings this depends on
 
 - *Actions → General → Allow GitHub Actions to create and approve pull requests* enabled.
 - `production` GitHub Environment holding `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` and the `VITE_API_BASE_URL` variable. CD stays paused until they exist: the `deploy` job also requires the repository variable `CD_ENABLED == 'true'`, gated at the caller because a job skipped inside a `workflow_call` target reports success.
+- Before real traffic: `apps/worker-api/wrangler.jsonc` `env.production.vars.CORS_ORIGINS` ships empty, so `/api/*` fails closed with 503 and the CD smoke fails *after* both promotes. Setting it takes a new release - vars ship inside the uploaded version, so a CD re-run cannot fix it.

--- a/.cursor/rules/ops/cd.mdc
+++ b/.cursor/rules/ops/cd.mdc
@@ -20,12 +20,12 @@ Weakening a deploy gate or shipping with missing credentials is covered by [`gua
 - **There is no `push: tags:` trigger, and adding one is a regression.** The release tag is created with `GITHUB_TOKEN`, and events created by that token do not start workflow runs, so a tag trigger never fires (GitHub `GITHUB_TOKEN` docs; changesets/action#669, changesets/changesets#1545). Zero tags existed while that dead trigger was the only path.
 - Do not deploy from `pull_request` or `pull_request_target` (the latter especially - base context plus untrusted checkout is a pwn pattern).
 - **Concurrency is `cd-production`, `cancel-in-progress: false`, `queue: max`.** Cancelling would drop an in-flight ship; and with the default `queue: single` a third trigger replaces the pending one, silently losing that release.
-- **Checkout uses `ref: ${{ inputs.tag }}`** - the ship must match the tagged commit, not whatever the branch tip is at job start.
+- **Checkout uses `ref: ${{ inputs.tag }}`** - the ship must match the tagged commit, not whatever the branch tip is at job start. The tag must be exactly `vX.Y.Z`: a changesets pre-mode tag (`v1.0.0-next.0`) fails closed at `Resolve release version` instead of shipping @100%, and that red run is by design. `RELEASE_SHA` (the tagged commit) is what upload messages and Release notes record - `GITHUB_SHA` points at the dispatching ref on `workflow_dispatch` redeploys.
 
 ## Auth and environment
 
 - **The job declares `environment: {name: production, url: …}`.** Protection rules, required reviewers, and environment secrets belong there. Do not move Cloudflare credentials into unprotected repository secrets "for convenience".
-- **Cloudflare credentials are never passed in by a caller.** `on.workflow_call.secrets` declares only `TURBO_TOKEN` and `TURBO_REMOTE_CACHE_SIGNATURE_KEY`; `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are resolved from the `production` environment by the job itself. Never switch the caller to `secrets: inherit`.
+- **Cloudflare credentials are never passed in by a caller.** `on.workflow_call.secrets` declares only `TURBO_TOKEN` and `TURBO_REMOTE_CACHE_SIGNATURE_KEY`; `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are resolved from the `production` environment by the individual wrangler steps via step-level `env:` - install, build, and smoke never see them. Never switch the caller to `secrets: inherit`, and never lift the credentials back to job-level `env:`. A new wrangler step must copy the two-line credentials `env:` block - the `Require deploy inputs` gate only vouches for its own copy.
 - **Both Cloudflare values are required** - the workflow fails closed if either is empty. Use a **scoped** Workers API token (Edit Cloudflare Workers, account-scoped), never a Global API Key, never a committed value. Secrets Store Edit only if the Worker binds Secrets Store.
 - **`VITE_API_BASE_URL` is a repository/environment *variable*, not a secret** - public build-time config for `front-app`, and the `environment.url`. Still required; empty fails.
 - **Wrangler auth in CI is non-interactive** via those env vars ([Cloudflare GitHub Actions guide](https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/)). Do not add `wrangler login` to CD.
@@ -35,9 +35,9 @@ Weakening a deploy gate or shipping with missing credentials is covered by [`gua
 
 - **This repo does not use `wrangler deploy` or `cloudflare/wrangler-action` in CD.** Package scripts `upload` / `promote` call `wrangler versions upload` then `wrangler versions deploy …@100% --yes` against the workspace-pinned Wrangler, keeping the CLI identical to local and avoiding a second floating action pin.
 - **Upload is machine-readable:** `WRANGLER_OUTPUT_FILE_PATH` captures JSON lines; CD parses `type === "version-upload"` for `version_id`. Do not replace that with scraping stdout.
-- **Keep `--strict`, and tag/message with the release version + `GITHUB_SHA`.** Cloudflare: `--strict` makes upload/deploy more defensive in non-interactive CI - do not drop it to force green.
+- **Keep `--strict`, and tag/message with the release version + `RELEASE_SHA` (the tagged commit).** Cloudflare: `--strict` makes upload/deploy more defensive in non-interactive CI - do not drop it to force green.
 - **Traffic policy today is 100%.** Gradual percentages exist; do not add them without observability and a rollback runbook.
-- **`versions upload` does not apply routes, custom domains, or cron triggers** ([deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)). When those land in `wrangler.jsonc`, also run `wrangler triggers deploy --env production` (comment already in the workflow).
+- **`versions upload` does not apply routes, custom domains, or cron triggers** ([deployment management](https://developers.cloudflare.com/workers/versions-and-deployments/deployment-management/)). When those land in `wrangler.jsonc`, also run `wrangler triggers deploy --env production` (comment beside the upload in `upload-version.sh`).
 - **Uploads may run in `parallel:`; promotes stay sequential.** `worker-api` then `front-app` at `@100%`. If front fails after API is live, production can be split - the workflow's error names the rollback (`wrangler rollback --env production`). Do not reorder or parallelize the two promotes without handling that partial state.
 
 ## Release and deployment records
@@ -47,7 +47,7 @@ Weakening a deploy gate or shipping with missing credentials is covered by [`gua
 
 ## Same hardening as CI
 
-SHA-pinned `uses:` with `# vX.Y.Z` comments; `persist-credentials: false` on checkout; workflow `permissions: {}` with per-job re-grants (`contents: write` for the Release, `deployments: write` for the environment record); runner `ubuntu-24.04`; frozen `pnpm install`; Node `24` via `pnpm/setup`; telemetry off. Multi-line shell uses `set -euo pipefail`. `$RUNNER_TEMP` only ever from a step - see the expression-context section in [`ops/ci.md`](ci.mdc), which is what broke this file once. Do not diverge "just for CD".
+SHA-pinned `uses:` with `# vX.Y.Z` comments; `persist-credentials: false` on checkout; workflow `permissions: {}` with per-job re-grants (`contents: write` for the Release, `deployments: write` for the environment record); runner `ubuntu-24.04`; frozen `pnpm install`; Node `24` via `pnpm/setup`; telemetry off. Step bodies live as scripts per the convention in [`ops/ci.md`](ci.mdc); the promotes and the smoke curl stay inline so the deploy-order coupling stays visible in the workflow. `$RUNNER_TEMP` only ever from a step - see the expression-context section in [`ops/ci.md`](ci.mdc), which is what broke this file once. Do not diverge "just for CD".
 
 ## What is deliberately not used
 

--- a/.cursor/rules/ops/ci.mdc
+++ b/.cursor/rules/ops/ci.mdc
@@ -1,6 +1,6 @@
 ---
 description: CI parity with pnpm ci, expression-context rules for env blocks, affected vs full graph by event, frozen lockfile, SHA pins, deny-by-default permissions
-globs: .github/workflows/**,.github/CODEOWNERS
+globs: .github/workflows/**,.github/actions/**,.github/CODEOWNERS
 alwaysApply: false
 ---
 
@@ -21,12 +21,13 @@ This is not hypothetical. `d3e741b` added `NODE_COMPILE_CACHE: ${{ runner.temp }
 ## Repo invariants
 
 - **Triggers:** `pull_request`, `workflow_call`, `workflow_dispatch`. **No `push:`** - pushes to `main` are covered by `release.yml`'s `gate`, so a commit is never checked twice.
-- **Parity:** root `pnpm ci` and the workflow run the same *kinds* of checks. Change both when adding or renaming a gate. Scope differs by event on purpose: `--affected` on `pull_request` only, full graph on `workflow_call` / `workflow_dispatch` (a release must validate everything). Two `if:`-gated steps express this - never interpolate the flag into a `run:` body.
+- **Parity:** root `pnpm ci` and the workflow run the same *kinds* of checks. Change both when adding or renaming a gate. Scope differs by event on purpose: `--affected` on `pull_request` only, full graph on `workflow_call` / `workflow_dispatch` (a release must validate everything). Two `if:`-gated steps express this - never interpolate the flag into a `run:` body. The dependency audit is `pull_request`-only for the inverse reason: the advisory DB changes daily, so an auditing release gate is not a pure function of the commit; local `pnpm run ci` still audits.
 - **`TURBO_SCM_BASE` is set on `pull_request` only,** to `origin/<base_ref>`; checkout only creates remote-tracking refs. It is deliberately empty elsewhere: the full-graph path needs no base, and `github.event.before` is all-zeros on a new branch, which silently degrades `--affected` to "everything changed". Keep `fetch-depth: 0` + `filter: blob:none`.
 - **Parallelization:** one job, using the GitHub Actions `parallel:` step keyword (GA 2026-06-25, alongside `background` / `wait` / `wait-all` / `cancel`) for OXC (`lint`/`format`), `boundaries`, `types:check`, `knip`, and `syncpack`. A `parallel:` list item takes **no sibling keys** - `parallel:` is its only property. A **single** `turbo run check-types test build` invocation, not two turbo CLIs; turbo schedules against default concurrency (no override in `turbo.json`). Wrangler deploy dry-run is `front-app` only after the join (`worker-api` build is already a dry-run).
 - **`changeset-release/**` is skipped** via a job-level `if` on `github.head_ref`. A `pull_request` `branches-ignore` filters the *base* branch and cannot do this. The release commit is validated by `gate` on the merge commit, so no branch-protection exemption is needed.
+- **Step bodies longer than a few lines live as scripts, not inline YAML:** workflow-invoked ones under `.github/actions/<workflow>/` (`cd/`, `release/`), composite-action ones beside their `action.yml`. Invoke with `bash <path>` and wire inputs through step-level `env:`; each script opens with `set -euo pipefail` and fails fast on missing input (`:?` guards or an explicit check). Short steps stay inline.
 - **Install:** `pnpm install --frozen-lockfile` after `pnpm/setup` with `install: false`. Node `runtime: node@24` matching root engines.
 - **Remote cache:** job env wires `TURBO_TOKEN`, `TURBO_TEAM`, and `TURBO_REMOTE_CACHE_SIGNATURE_KEY` (repo secret, >= 32 bytes, same value as local machines - `turbo.json` enables `remoteCache.signature` + `longerSignatureKey`). `workflow_call` declares those two secrets **explicitly** so the release gate never receives Cloudflare credentials; never switch that call to `secrets: inherit`.
-- **Pins:** every `uses:` is a full-length commit SHA with a `# vX.Y.Z` comment. `actions/checkout` sets `persist-credentials: false`. Workflow `permissions: {}` with per-job re-grants. Runners: `ubuntu-24.04` (not `ubuntu-latest`).
+- **Pins:** every `uses:` is a full-length commit SHA with a `# vX.Y.Z` comment. `actions/checkout` sets `persist-credentials: false`. Workflow `permissions: {}` with per-job re-grants - `contents: read` only, since artifact upload and the setup caches use the runner's runtime token, not `GITHUB_TOKEN`. Runners: `ubuntu-24.04` (not `ubuntu-latest`).
 - **`cancel-in-progress` only on pull_request.** Never interpolate `github.ref_name` into script bodies. No production/Cloudflare secrets in this workflow (CD only).
 - Do not add scanners "for completeness" without a concrete threat and owner. Telemetry stays off at workflow `env:`.

--- a/.cursor/rules/ops/release.mdc
+++ b/.cursor/rules/ops/release.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # Releases
 
-[Changesets](https://changesets.dev) computes versions; the pipeline is [`.github/workflows/release.yml`](../../../.github/workflows/release.yml). Read it for the job list. Human-facing "how do I" lives in [`.changeset/README.md`](../../../.changeset/README.md); CI internals in [`ops/ci.md`](ci.mdc); the deploy in [`ops/cd.md`](cd.mdc).
+[Changesets](https://changesets.dev) computes versions; the pipeline is [`.github/workflows/release.yml`](../../../.github/workflows/release.yml). Read it for the job list; long step bodies live as `bash`-invoked scripts under `.github/actions/` (convention: [`ops/ci.md`](ci.mdc)). Human-facing "how do I" lives in [`.changeset/README.md`](../../../.changeset/README.md); CI internals in [`ops/ci.md`](ci.mdc); the deploy in [`ops/cd.md`](cd.mdc).
 
 Nothing is published to npm. Every workspace is `private: true`, no `publishConfig`, no `.npmrc`. **A release is a git tag plus a Cloudflare Workers promote.**
 
@@ -23,9 +23,9 @@ push to main ──► Release  (concurrency release-main, queue: max, never can
 ## Invariants
 
 - **`gate` runs on every push to main, in both modes.** While a release PR is open the mode is always `version`, so a gate placed only on the release path would leave `main` unvalidated for that PR's whole life. Do not move it under the `mode != 'version'` branch.
-- **The tag is the idempotency key.** `create-release-tag` skips when `vX.Y.Z` exists and reports `created=false`; `deploy` is gated on `created == 'true'`, so re-running `Release` never re-deploys. To redeploy on purpose use `cd.yml`'s `workflow_dispatch` with the tag.
+- **The tag is the idempotency key.** `create-release-tag` skips when `vX.Y.Z` exists and reports `created=false`; `deploy` is gated on `created == 'true'`, so re-running `Release` never re-deploys. The existence probe is three-way: 2xx skips, 404 creates, and any other probe failure fails the job rather than guessing. To redeploy on purpose use `cd.yml`'s `workflow_dispatch` with the tag.
 - **`mode != 'version'`, not `mode == 'publish'`.** `select-mode` returns `publish` only when publishable packages exist, and all of ours are private, so `publish` is unreachable and the equality test would never fire. This condition is load-bearing.
-- **`privatePackages.tag: false` is deliberate.** `changeset tag` would emit `front-app@X.Y.Z` and `worker-api@X.Y.Z`; the deploy keys on one shared `vX.Y.Z`, which is why the tag is cut by `create-release-tag` instead.
+- **`privatePackages.tag: false` is deliberate.** `changeset git-tag` (the v3 name of `changeset tag`) would emit `front-app@X.Y.Z` and `worker-api@X.Y.Z`; the deploy keys on one shared `vX.Y.Z`, which is why the tag is cut by `create-release-tag` instead.
 - **`baseBranch: "main"` and `privatePackages.version: true` are load-bearing.** The documented defaults are `"master"` and `{version: false, tag: false}` — the latter would version nothing at all here.
 - **The version PR branch is force-pushed, not accumulated.** Every push to `main` resets `changeset-release/main` from the tip, re-runs `changeset version`, and force-pushes one commit. It can never be behind `main` or conflict with it, and manual edits to it are destroyed. Verified on PR #19: base tracked the newest `main` SHA with a single commit.
 - **Tags created with `GITHUB_TOKEN` do not trigger workflows.** This is why `cd.yml` has no `push: tags:` trigger and `release.yml` calls it directly. Do not "restore" a tag trigger; it is dead code (GitHub `GITHUB_TOKEN` docs; changesets/action#669).
@@ -40,9 +40,10 @@ push to main ──► Release  (concurrency release-main, queue: max, never can
 | `version` push rejected | Re-run; the branch is reset from `main` each time. |
 | `tag` version drift | Re-align both apps in one commit; the action fails closed. |
 | Tag already exists | `created=false`, deploy skipped. Not an error. |
-| `deploy` upload/promote/smoke | Tag stands. Re-run `cd.yml` via `workflow_dispatch` with the tag, or `pnpm --filter=<app> exec wrangler rollback --env production`. |
+| `deploy` upload/promote/smoke | Tag stands. "Re-run failed jobs" on the Release run retries the deploy (the `tag` job's `created=true` output is preserved; "re-run all jobs" instead re-probes, gets `created=false`, and skips - safe, not a retry), or run `cd.yml` via `workflow_dispatch` with the tag. Rollback: `pnpm --filter=<app> exec wrangler rollback --env production`. |
 
 ## Repo settings this depends on
 
 - *Actions → General → Allow GitHub Actions to create and approve pull requests* enabled.
 - `production` GitHub Environment holding `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` and the `VITE_API_BASE_URL` variable. CD stays paused until they exist: the `deploy` job also requires the repository variable `CD_ENABLED == 'true'`, gated at the caller because a job skipped inside a `workflow_call` target reports success.
+- Before real traffic: `apps/worker-api/wrangler.jsonc` `env.production.vars.CORS_ORIGINS` ships empty, so `/api/*` fails closed with 503 and the CD smoke fails *after* both promotes. Setting it takes a new release - vars ship inside the uploaded version, so a CD re-run cannot fix it.

--- a/.github/actions/cd/create-github-release.sh
+++ b/.github/actions/cd/create-github-release.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Purpose: Create or update the GitHub Release for the deployed tag, with both
+# Workers' version ids and the matching CHANGELOG sections in the notes.
+# Target: called by cd.yml with GH_TOKEN and the guarded variables below.
+set -euo pipefail
+: "${TAG:?TAG is required (vX.Y.Z)}"
+: "${VERSION:?VERSION is required (X.Y.Z)}"
+: "${RELEASE_SHA:?RELEASE_SHA is required}"
+: "${VITE_API_BASE_URL:?VITE_API_BASE_URL is required}"
+: "${WORKER_API_VERSION_ID:?WORKER_API_VERSION_ID is required}"
+: "${FRONT_APP_VERSION_ID:?FRONT_APP_VERSION_ID is required}"
+
+notes="$(mktemp)"
+{
+  echo "Deployed \`worker-api\` and \`front-app\` @ \`${VERSION}\` to production."
+  echo
+  echo "- Commit: ${RELEASE_SHA}"
+  echo "- worker-api version id: \`${WORKER_API_VERSION_ID}\`"
+  echo "- front-app version id: \`${FRONT_APP_VERSION_ID}\`"
+  echo "- URL: ${VITE_API_BASE_URL}"
+  for app in worker-api front-app; do
+    changelog="apps/${app}/CHANGELOG.md"
+    [ -f "$changelog" ] || continue
+    excerpt="$(
+      awk -v ver="$VERSION" '
+        $0 == "## " ver { flag = 1; next }
+        /^## / && flag { exit }
+        flag { print }
+      ' "$changelog"
+    )"
+    [[ -n "${excerpt//[[:space:]]/}" ]] || continue
+    echo
+    echo "### ${app}"
+    echo "$excerpt"
+  done
+} > "$notes"
+
+if gh release view "$TAG" > /dev/null 2>&1; then
+  gh release edit "$TAG" --title "$TAG" --notes-file "$notes"
+else
+  gh release create "$TAG" --title "$TAG" --notes-file "$notes" --verify-tag
+fi

--- a/.github/actions/cd/require-deploy-inputs.sh
+++ b/.github/actions/cd/require-deploy-inputs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Purpose: Fail the deploy before any install/build work when credentials or the
+# front-app origin are missing, with a named message instead of wrangler's auth error.
+# Target: called by cd.yml.
+set -euo pipefail
+
+: "${CLOUDFLARE_API_TOKEN:?required for CD - a production GitHub Environment secret}"
+: "${CLOUDFLARE_ACCOUNT_ID:?required for CD - a production GitHub Environment secret}"
+: "${VITE_API_BASE_URL:?repository variable required for front-app}"

--- a/.github/actions/cd/resolve-release-version.sh
+++ b/.github/actions/cd/resolve-release-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Purpose: Derive VERSION and RELEASE_SHA for the deploy from the tag input.
+# Target: called by cd.yml after the tag checkout, with TAG in the environment.
+set -euo pipefail
+: "${TAG:?TAG is required (vX.Y.Z)}"
+
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "::error::TAG must be exactly vX.Y.Z, got: $TAG" >&2
+  exit 1
+fi
+echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"
+# GITHUB_SHA points at the dispatching ref on workflow_dispatch redeploys, not the tag.
+echo "RELEASE_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"

--- a/.github/actions/cd/upload-version.sh
+++ b/.github/actions/cd/upload-version.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Purpose: wrangler versions upload for one app, emitting its new version id.
+# Target: called by cd.yml with APP, VERSION, RELEASE_SHA, and the Cloudflare
+# credentials in the environment; writes version-id to GITHUB_OUTPUT.
+set -euo pipefail
+: "${APP:?APP is required (worker-api | front-app)}"
+: "${VERSION:?VERSION is required (X.Y.Z)}"
+: "${RELEASE_SHA:?RELEASE_SHA is required}"
+
+# When wrangler.jsonc gains routes/custom domains/cron triggers, also run:
+#   pnpm --filter="$APP" exec wrangler triggers deploy --env production
+out="$(mktemp)"
+WRANGLER_OUTPUT_FILE_PATH="$out" pnpm --filter="$APP" run upload -- \
+  --strict --tag "$VERSION" --message "release $VERSION (${RELEASE_SHA})"
+version_id="$(jq -r -s 'map(select(.type == "version-upload" and .version_id)) | last | .version_id' "$out")"
+if [ -z "$version_id" ] || [ "$version_id" = "null" ]; then
+  echo "::error::wrangler versions upload did not emit version-upload.version_id" >&2
+  exit 1
+fi
+echo "version-id=${version_id}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/create-release-tag/action.yml
+++ b/.github/actions/create-release-tag/action.yml
@@ -25,18 +25,6 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
         VERSION: ${{ steps.version.outputs.version }}
-      run: |
-        set -euo pipefail
-        tag="v${VERSION}"
-        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-        if gh api "repos/${{ github.repository }}/git/ref/tags/${tag}" > /dev/null 2>&1; then
-          echo "Tag ${tag} already exists; nothing to release."
-          echo "created=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-        echo "Creating tag ${tag} at ${GITHUB_SHA}"
-        gh api "repos/${{ github.repository }}/git/refs" \
-          -f "ref=refs/tags/${tag}" \
-          -f "sha=${GITHUB_SHA}"
-        echo "created=true" >> "$GITHUB_OUTPUT"
+      run: bash "${{ github.action_path }}/create-release-tag.sh"

--- a/.github/actions/create-release-tag/create-release-tag.sh
+++ b/.github/actions/create-release-tag/create-release-tag.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Purpose: Tag the current commit vX.Y.Z, idempotently, via the GitHub API.
+# Target: called by action.yml; gh resolves {owner}/{repo} placeholders from GH_REPO.
+set -euo pipefail
+: "${GH_REPO:?GH_REPO is required (owner/repo)}"
+: "${VERSION:?VERSION is required (X.Y.Z)}"
+
+tag="v${VERSION}"
+echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+# 2xx = tag exists (skip), 404 = create, anything else fails rather than guessing.
+if lookup="$(gh api "repos/{owner}/{repo}/git/ref/tags/${tag}" 2>&1)"; then
+  echo "Tag ${tag} already exists; nothing to release."
+  echo "created=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+if [[ "$lookup" != *"(HTTP 404)"* ]]; then
+  echo "::error::Existence probe for ${tag} failed (not a 404); refusing to guess." >&2
+  printf '%s\n' "$lookup" >&2
+  exit 1
+fi
+
+echo "Creating tag ${tag} at ${GITHUB_SHA}"
+gh api "repos/{owner}/{repo}/git/refs" \
+  -f "ref=refs/tags/${tag}" \
+  -f "sha=${GITHUB_SHA}"
+echo "created=true" >> "$GITHUB_OUTPUT"

--- a/.github/actions/release/comment-release-pr-contract.sh
+++ b/.github/actions/release/comment-release-pr-contract.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Purpose: Pin the repo-accurate merge contract onto the "chore: release" PR - the
+# changesets/action description promises an npm publish that never happens here.
+# Target: called by release.yml (Correct the release PR contract step) with
+# GH_TOKEN and PR_NUMBER in the environment.
+#
+# --edit-last --create-if-none keeps this to one comment across the many times the
+# version job re-runs while the release PR is open.
+set -euo pipefail
+: "${PR_NUMBER:?PR_NUMBER is required}"
+
+gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body-file - <<'BODY'
+### What merging this PR does
+
+**No npm publish happens.** Every workspace in this repo is `private: true`; there is
+no `publishConfig` and no registry configured. Disregard the "published to npm
+automatically" line in the description above.
+
+Merging this PR:
+
+1. lands the version bumps and `CHANGELOG.md` entries on `main`;
+2. makes the `Release` workflow validate that commit with full-graph CI;
+3. cuts the tag `v<version>` at it - the single release coordinate for both apps;
+4. hands that tag to `CD`, which uploads and promotes both Workers to 100%.
+
+Do not push edits to `changeset-release/main`: this branch is reset from the `main`
+tip and force-pushed on every push to `main`, so the commit would be discarded.
+Corrections belong in a new changeset on `main`.
+BODY

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,10 @@ worker-api:
   - changed-files:
       - any-glob-to-any-file: apps/worker-api/**
 
+correlation-id:
+  - changed-files:
+      - any-glob-to-any-file: packages/correlation-id/**
+
 dtos-common:
   - changed-files:
       - any-glob-to-any-file: packages/dtos-common/**
@@ -40,6 +44,10 @@ docs:
 ci:
   - changed-files:
       - any-glob-to-any-file: .github/**
+
+release:
+  - changed-files:
+      - any-glob-to-any-file: .changeset/**
 
 hooks:
   - changed-files:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ on:
         type: string
     secrets:
       # Cloudflare credentials are absent on purpose: they live on the `production`
-      # Environment and are resolved by the job, never passed in by a caller.
+      # Environment, never passed in by a caller.
       TURBO_TOKEN:
         required: false
       TURBO_REMOTE_CACHE_SIGNATURE_KEY:
@@ -49,16 +49,15 @@ jobs:
     permissions:
       contents: write # GitHub Release
       deployments: write # deployment record for the `production` environment
+    # Cloudflare and GitHub tokens are step-scoped below on purpose - install, build,
+    # and smoke never see them.
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
       NODE_ENV: production
       TAG: ${{ inputs.tag }}
-      GH_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -68,24 +67,13 @@ jobs:
           fetch-depth: 1
 
       - name: Resolve release version
-        run: |
-          set -euo pipefail
-          case "$TAG" in
-            v[0-9]*.[0-9]*.[0-9]*) ;;
-            *) echo "::error::TAG must look like vX.Y.Z, got: $TAG" >&2; exit 1 ;;
-          esac
-          echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"
+        run: bash .github/actions/cd/resolve-release-version.sh
 
-      - name: Require Cloudflare credentials
-        run: |
-          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
-            echo "ERROR: CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required for CD" >&2
-            exit 1
-          fi
-          if [ -z "$VITE_API_BASE_URL" ]; then
-            echo "ERROR: repository variable VITE_API_BASE_URL is required for front-app" >&2
-            exit 1
-          fi
+      - name: Require deploy inputs
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bash .github/actions/cd/require-deploy-inputs.sh
 
       - name: Setup pnpm and Node.js
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
@@ -104,95 +92,49 @@ jobs:
 
       - run: pnpm turbo run build --filter=worker-api --filter=front-app
 
-      # When wrangler.jsonc gains routes/custom domains/cron triggers, also run:
-      #   pnpm --filter="$app" exec wrangler triggers deploy --env production
       - parallel:
           - name: Upload worker-api
             id: upload-api
-            run: |
-              set -euo pipefail
-              out="$(mktemp)"
-              WRANGLER_OUTPUT_FILE_PATH="$out" pnpm --filter=worker-api run upload -- \
-                --strict --tag "$VERSION" --message "release $VERSION (${GITHUB_SHA})"
-              version_id="$(jq -r -s 'map(select(.type == "version-upload" and .version_id)) | last | .version_id' "$out")"
-              if [ -z "$version_id" ] || [ "$version_id" = "null" ]; then
-                echo "::error::wrangler versions upload did not emit version-upload.version_id" >&2
-                exit 1
-              fi
-              echo "version-id=${version_id}" >> "$GITHUB_OUTPUT"
-              rm -f "$out"
+            env:
+              APP: worker-api
+              CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+              CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+            run: bash .github/actions/cd/upload-version.sh
 
           - name: Upload front-app
             id: upload-front
-            run: |
-              set -euo pipefail
-              out="$(mktemp)"
-              WRANGLER_OUTPUT_FILE_PATH="$out" pnpm --filter=front-app run upload -- \
-                --strict --tag "$VERSION" --message "release $VERSION (${GITHUB_SHA})"
-              version_id="$(jq -r -s 'map(select(.type == "version-upload" and .version_id)) | last | .version_id' "$out")"
-              if [ -z "$version_id" ] || [ "$version_id" = "null" ]; then
-                echo "::error::wrangler versions upload did not emit version-upload.version_id" >&2
-                exit 1
-              fi
-              echo "version-id=${version_id}" >> "$GITHUB_OUTPUT"
-              rm -f "$out"
+            env:
+              APP: front-app
+              CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+              CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+            run: bash .github/actions/cd/upload-version.sh
 
       - name: Promote worker-api @100%
-        run: |
-          set -euo pipefail
-          pnpm --filter=worker-api run promote -- \
-            "${{ steps.upload-api.outputs.version-id }}@100%" --yes
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          VERSION_ID: ${{ steps.upload-api.outputs.version-id }}
+        run: pnpm --filter=worker-api run promote -- "${VERSION_ID}@100%" --yes
 
       - name: Promote front-app @100%
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          VERSION_ID: ${{ steps.upload-front.outputs.version-id }}
         run: |
-          set -euo pipefail
-          if ! pnpm --filter=front-app run promote -- \
-            "${{ steps.upload-front.outputs.version-id }}@100%" --yes; then
+          if ! pnpm --filter=front-app run promote -- "${VERSION_ID}@100%" --yes; then
             echo "::error::front-app deploy failed after worker-api may already be live at 100%. Rollback with: pnpm --filter=worker-api exec wrangler rollback --env production"
             exit 1
           fi
 
       - name: Smoke production health
-        run: |
-          set -euo pipefail
-          curl --fail --silent --show-error --max-time 30 "${VITE_API_BASE_URL}/api/v1/health"
+        run: curl --fail --silent --show-error --max-time 30 "${VITE_API_BASE_URL}/api/v1/health"
 
       # GitHub creates the deployment record from the `environment:` above; only the
       # Release is ours to write.
       - name: Create GitHub Release
         env:
+          GH_TOKEN: ${{ github.token }}
           WORKER_API_VERSION_ID: ${{ steps.upload-api.outputs.version-id }}
           FRONT_APP_VERSION_ID: ${{ steps.upload-front.outputs.version-id }}
-        run: |
-          set -euo pipefail
-          notes="$(mktemp)"
-          {
-            echo "Deployed \`worker-api\` and \`front-app\` @ \`${VERSION}\` to production."
-            echo
-            echo "- Commit: ${GITHUB_SHA}"
-            echo "- worker-api version id: \`${WORKER_API_VERSION_ID}\`"
-            echo "- front-app version id: \`${FRONT_APP_VERSION_ID}\`"
-            echo "- URL: ${VITE_API_BASE_URL}"
-            for app in worker-api front-app; do
-              changelog="apps/${app}/CHANGELOG.md"
-              [ -f "$changelog" ] || continue
-              excerpt="$(
-                awk -v ver="$VERSION" '
-                  $0 == "## " ver { flag = 1; next }
-                  /^## / && flag { exit }
-                  flag { print }
-                ' "$changelog"
-              )"
-              [ -n "$(printf '%s' "$excerpt" | tr -d '[:space:]')" ] || continue
-              echo
-              echo "### ${app}"
-              echo "$excerpt"
-            done
-          } > "$notes"
-
-          if gh release view "$TAG" > /dev/null 2>&1; then
-            gh release edit "$TAG" --title "$TAG" --notes-file "$notes"
-          else
-            gh release create "$TAG" --title "$TAG" --notes-file "$notes" --verify-tag
-          fi
-          rm -f "$notes"
+        run: bash .github/actions/cd/create-github-release.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      actions: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -69,7 +68,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - parallel:
+          # PR-only: the release gate must stay a pure function of the commit.
           - name: Dependency audit
+            if: github.event_name == 'pull_request'
             run: pnpm run audit
 
           - name: Boundaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
     name: Validate main
     permissions:
       contents: read
-      actions: write
     uses: ./.github/workflows/ci.yml
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -44,13 +43,8 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 1
-      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
-        with:
-          runtime: node@24
-          cache: true
-          cache-dependency-path: pnpm-lock.yaml
-          install: false
-      - run: pnpm install --frozen-lockfile
+      # No pnpm/setup or install: select-mode is a bundled action and, unlike
+      # changesets/action/version, does not need @changesets/cli resolvable.
       - id: select-mode
         uses: changesets/action/select-mode@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
 
@@ -67,7 +61,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          fetch-depth: 1
+          # Full history: changelog commit attribution (@changesets/git
+          # getCommitsThatAddFiles) loops `git fetch --deepen=50` in shallow clones,
+          # an anonymous fetch under persist-credentials: false. blob:none keeps it cheap.
+          fetch-depth: 0
+          filter: blob:none
       - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
           runtime: node@24
@@ -85,33 +83,12 @@ jobs:
           # @changesets/changelog-github inside the `changeset version` child process.
           GITHUB_TOKEN: ${{ github.token }}
 
-      # --edit-last --create-if-none keeps this to one comment across the many times this
-      # job re-runs while the release PR is open.
       - name: Correct the release PR contract
         if: steps.version.outputs.pr-number != ''
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.version.outputs.pr-number }}
-        run: |
-          set -euo pipefail
-          gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body-file - <<'BODY'
-          ### What merging this PR does
-
-          **No npm publish happens.** Every workspace in this repo is `private: true`; there is
-          no `publishConfig` and no registry configured. Disregard the "published to npm
-          automatically" line in the description above.
-
-          Merging this PR:
-
-          1. lands the version bumps and `CHANGELOG.md` entries on `main`;
-          2. makes the `Release` workflow validate that commit with full-graph CI;
-          3. cuts the tag `v<version>` at it - the single release coordinate for both apps;
-          4. hands that tag to `CD`, which uploads and promotes both Workers to 100%.
-
-          Do not push edits to `changeset-release/main`: this branch is reset from the `main`
-          tip and force-pushed on every push to `main`, so the commit would be discarded.
-          Corrections belong in a new changeset on `main`.
-          BODY
+        run: bash .github/actions/release/comment-release-pr-contract.sh
 
   tag:
     name: Tag release

--- a/README.md
+++ b/README.md
@@ -377,15 +377,16 @@ wrangler dev -c apps/worker-api/wrangler.jsonc -c apps/worker-example/wrangler.j
 
 Versioning is [Changesets](https://changesets.dev). `front-app` and `worker-api` are a `fixed` group, so they always share one version - which is what makes a single `vX.Y.Z` tag a valid release coordinate. **Nothing is published to npm**: every workspace is `private: true`. A release is a git tag plus a Cloudflare Workers promote.
 
-```text
-PR ──► CI (--affected) + advisory "does this need a changeset?" comment
-
-merge to main ──► Release workflow
-  gate         ALWAYS: runs CI on the merge commit, full graph
-  select-mode  changesets pending? → open/update the "chore: release" PR   [END]
-               none?               → tag vX.Y.Z (after gate) → newly created?
-                                       → CD: versions upload --tag X.Y.Z
-                                         → promote @100% → smoke → GitHub Release
+```mermaid
+flowchart LR
+  PR["PR + changeset"] -->|"CI --affected +<br/>changeset status comment"| M["merge to main"]
+  M --> G["gate<br/>full-graph CI, always"]
+  M --> S["select-mode"]
+  S -->|"changesets pending"| V["chore: release PR<br/>(branch reset + force-pushed)"]
+  V -->|merge| M
+  S -->|"none pending"| T["create-release-tag<br/>idempotent vX.Y.Z"]
+  G --> T
+  T -->|"newly created +<br/>CD_ENABLED"| D["CD: versions upload --tag X.Y.Z<br/>promote @100% → smoke → GitHub Release"]
 ```
 
 Day to day:
@@ -410,7 +411,7 @@ Contributor walkthrough: [`.changeset/README.md`](.changeset/README.md). Pipelin
 for `worker-api` and `front-app`. Uploads run in parallel; promotes stay sequential (`worker-api` first) so a partial production state is attributable.
 
 > [!NOTE]
-> **CD is paused** until production Environment secrets are configured. Set the repository variable `CD_ENABLED` to `true` in the same act as adding them. Until then, use the local helpers below.
+> **CD is paused** until production Environment secrets are configured. Set the repository variable `CD_ENABLED` to `true` in the same act as adding them. Until then, use the local helpers below. Before real traffic, also set `CORS_ORIGINS` in `apps/worker-api/wrangler.jsonc` under `env.production.vars` - it ships empty, which fails closed (`/api/*` returns 503, so the CD smoke check fails after both Workers are promoted), and because vars ship inside the uploaded version the fix needs a new release, not a CD re-run.
 
 Recovering from a failed release (full table in [`.claude/rules/ops/release.md`](.claude/rules/ops/release.md)):
 


### PR DESCRIPTION
## What

A ground-truth audit of the release pipeline (Changesets v3, GitHub Actions, pnpm 11, Wrangler gradual deployments) against current official docs, followed by targeted hardening. The architecture is unchanged — granular changesets sub-actions, gate-then-tag on main, CD called directly with the tag — the defects were in the details:

- **Privilege**: drop the dead `actions: write` grant in `ci.yml` + the release gate (upload-artifact v7 takes no token); step-scope `CLOUDFLARE_*`/`GH_TOKEN` in `cd.yml` so install/build/smoke never see credentials; route step outputs through `env:` instead of `run:`-body interpolation.
- **Idempotency**: three-way tag-existence probe — 2xx skips, 404 creates, anything else fails the job (previously any probe failure fell through to create → 422 on re-runs).
- **Determinism**: version job checks out full history (`blob:none`) so changelog attribution stops depending on anonymous `git fetch --deepen` loops (hard failure on private clones); registry audit is `pull_request`-only so tagging a merged commit is a pure function of that commit.
- **Fail-closed**: CD accepts exactly `vX.Y.Z` (pre-mode tags fail closed); `RELEASE_SHA` recorded everywhere (`GITHUB_SHA` is wrong on `workflow_dispatch` redeploys).
- **Waste**: `select-mode` job loses its pointless `pnpm install` (bundled action) — one full workspace install saved on every push to main.
- **Readability**: long step bodies extracted to env-wired, `:?`-guarded bash scripts under `.github/actions/{cd,release,create-release-tag}/`; one shared upload script replaces two duplicated inline bodies; release flow rendered as mermaid in the README.
- **Docs/labels**: ops rules synced in both trees (`changeset git-tag` rename, re-run recovery semantics, `CORS_ORIGINS` go-live prerequisite, script-extraction convention now in `ops/ci.md` whose scope covers the scripts); `release` + `correlation-id` labeler entries.

## Validation

- All touched YAML parses with structural assertions (permissions, step-scoped env, script wiring).
- `bash -n` + functional tests on every script: probe's three branches with a stubbed `gh`, tag regex against hostile inputs, `:?` guards, changelog-section extraction.
- Full `pnpm run ci` green (46 tests); `pnpm release:status` unchanged (pending `v0.1.0`).
- Reviewed by a 4-angle `/simplify` pass (reuse / simplification / efficiency / altitude); fixes applied.

No changeset: CI/docs/tooling-only, no deployable app code.