### PR TITLE
chore: trim boilerplate comments, fold duplicated patterns into rules

### DIFF
--- a/.claude/rules/quality/knip.md
+++ b/.claude/rules/quality/knip.md
@@ -41,6 +41,6 @@ Root `knip.jsonc` is intentionally comment-free; every override's rationale live
 
 - Both passes must stay green: `pnpm knip` (default) and `pnpm knip:production` (`--production --strict`: shipped-code-only + workspace isolation). Both run inside `pnpm run ci`.
 - Never blanket-`ignore`. Prefer scoped patterns (`ignoreIssues`, `ignoreFiles`, production-only suffixes like `"dep!"` / `"!pattern!"`).
-- Exports kept solely for unit tests carry an explicit JSDoc `@internal` tag - production mode ignores tagged exports, so tests never mask dead shipped API.
+- Exports kept solely for unit tests carry an explicit JSDoc `@internal` tag - production mode ignores tagged exports, so tests never mask dead shipped API - the tag alone is the reason, don't add prose above it restating "extracted/exported for tests".
 - Auto-fix unused dependencies and pnpm catalog entries with `knip --fix --fix-type dependencies,catalog`; agent-readable output via `pnpm knip:agent` (`--reporter symbols`).
 - Generated files (`routeTree.gen.ts`, `worker-configuration.d.ts`) resolve cleanly today; if they ever false-positive, use `ignoreIssues` scoped patterns, not blanket `ignore`.

--- a/.claude/rules/tests/hono-workers.md
+++ b/.claude/rules/tests/hono-workers.md
@@ -19,3 +19,4 @@ Governs Vitest for Hono apps on Cloudflare Workers via `@cloudflare/vitest-plugi
 - Types: `tests/env.d.ts` with `ProvidedEnv extends Env`; tests tsconfig includes `@cloudflare/vitest-plugin/types` and committed `worker-configuration.d.ts`.
 - Assert status/body/headers/binding state - not `toBeDefined()`-only. Agents: `pnpm turbo run test --filter=<app>` non-watch.
 - Keep this pool for unit/route tests. Add Wrangler `createTestHarness` only for multi-Worker production-build integration when a service binding exists - do not replace these suites. See `packages/vitest-config/AGENTS.md`.
+- Every route test imports the Worker entry (`import app from "../src/index"` or a relative equivalent) immediately followed by `void app;`, uncommented - the unused-looking side-effect import is what makes Vitest re-run the suite when the entry module changes.

--- a/.cursor/rules/quality/knip.mdc
+++ b/.cursor/rules/quality/knip.mdc
@@ -42,6 +42,6 @@ Root `knip.jsonc` is intentionally comment-free; every override's rationale live
 
 - Both passes must stay green: `pnpm knip` (default) and `pnpm knip:production` (`--production --strict`: shipped-code-only + workspace isolation). Both run inside `pnpm run ci`.
 - Never blanket-`ignore`. Prefer scoped patterns (`ignoreIssues`, `ignoreFiles`, production-only suffixes like `"dep!"` / `"!pattern!"`).
-- Exports kept solely for unit tests carry an explicit JSDoc `@internal` tag - production mode ignores tagged exports, so tests never mask dead shipped API.
+- Exports kept solely for unit tests carry an explicit JSDoc `@internal` tag - production mode ignores tagged exports, so tests never mask dead shipped API - the tag alone is the reason, don't add prose above it restating "extracted/exported for tests".
 - Auto-fix unused dependencies and pnpm catalog entries with `knip --fix --fix-type dependencies,catalog`; agent-readable output via `pnpm knip:agent` (`--reporter symbols`).
 - Generated files (`routeTree.gen.ts`, `worker-configuration.d.ts`) resolve cleanly today; if they ever false-positive, use `ignoreIssues` scoped patterns, not blanket `ignore`.

--- a/.cursor/rules/tests/hono-workers.mdc
+++ b/.cursor/rules/tests/hono-workers.mdc
@@ -17,3 +17,4 @@ Governs Vitest for Hono apps on Cloudflare Workers via `@cloudflare/vitest-plugi
 - Types: `tests/env.d.ts` with `ProvidedEnv extends Env`; tests tsconfig includes `@cloudflare/vitest-plugin/types` and committed `worker-configuration.d.ts`.
 - Assert status/body/headers/binding state - not `toBeDefined()`-only. Agents: `pnpm turbo run test --filter=<app>` non-watch.
 - Keep this pool for unit/route tests. Add Wrangler `createTestHarness` only for multi-Worker production-build integration when a service binding exists - do not replace these suites. See `packages/vitest-config/AGENTS.md`.
+- Every route test imports the Worker entry (`import app from "../src/index"` or a relative equivalent) immediately followed by `void app;`, uncommented - the unused-looking side-effect import is what makes Vitest re-run the suite when the entry module changes.

--- a/apps/front-app/src/hooks/use-api-health.ts
+++ b/apps/front-app/src/hooks/use-api-health.ts
@@ -6,11 +6,7 @@ type UseApiHealthResult = {
   status: ApiHealthStatus;
 };
 
-/**
- * Pure reducer extracted for unit testing.
- *
- * @internal
- */
+/** @internal */
 export function resolveApiHealthStatus({
   isFetching,
   isPending,

--- a/apps/front-app/src/utils/api-health-dot.ts
+++ b/apps/front-app/src/utils/api-health-dot.ts
@@ -34,11 +34,7 @@ export function getApiHealthPresentation(
   return API_HEALTH_PRESENTATION[apiHealthStatus];
 }
 
-/**
- * Pure mapper extracted for unit testing.
- *
- * @internal
- */
+/** @internal */
 export function getApiHealthDotClassName(
   apiHealthStatus: ApiHealthStatus,
 ): string {

--- a/apps/worker-api/src/middlewares/cors-origins.ts
+++ b/apps/worker-api/src/middlewares/cors-origins.ts
@@ -3,7 +3,7 @@ import { isStrictCorsAppEnvironment } from "@repo/enums-common";
 /**
  * `null` means permissive mode (any origin) — allowed in non-strict envs only.
  *
- * @internal Exported for unit tests.
+ * @internal
  */
 export function parseCorsOrigins(value: string | undefined): string[] | null {
   if (value === undefined || value.trim() === "") {

--- a/apps/worker-api/tests/index.test.ts
+++ b/apps/worker-api/tests/index.test.ts
@@ -1,6 +1,5 @@
 import { exports } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
-// Side-effect import so Vitest re-runs when the Worker entry changes.
 import app from "../src/index";
 
 void app;

--- a/apps/worker-api/tests/routes/echo.test.ts
+++ b/apps/worker-api/tests/routes/echo.test.ts
@@ -2,7 +2,6 @@ import { EchoResponseSchema } from "@repo/dtos-common/api";
 import { AppEnvironment } from "@repo/enums-common";
 import { env, exports } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
-// Side-effect import so Vitest re-runs when the Worker entry changes.
 import app from "../../src/index";
 
 void app;

--- a/apps/worker-api/tests/routes/health.test.ts
+++ b/apps/worker-api/tests/routes/health.test.ts
@@ -1,7 +1,6 @@
 import { HealthResponseSchema } from "@repo/dtos-common/api";
 import { exports } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
-// Side-effect import so Vitest re-runs when the Worker entry changes.
 import app from "../../src/index";
 
 void app;

--- a/packages/correlation-id/vitest.config.ts
+++ b/packages/correlation-id/vitest.config.ts
@@ -1,7 +1,5 @@
 import { defineNodeConfig, resolvePackageRoot } from "@repo/vitest-config";
 
-// realpath so Vitest VS Code explorer path walks match its workspace cache
-// (Fatal Error: Attempted to get parent of root folder "/").
 const root = resolvePackageRoot(import.meta.dirname);
 
 export default defineNodeConfig({

--- a/packages/dtos-common/vitest.config.ts
+++ b/packages/dtos-common/vitest.config.ts
@@ -1,7 +1,5 @@
 import { defineNodeConfig, resolvePackageRoot } from "@repo/vitest-config";
 
-// realpath so Vitest VS Code explorer path walks match its workspace cache
-// (Fatal Error: Attempted to get parent of root folder "/").
 const root = resolvePackageRoot(import.meta.dirname);
 
 export default defineNodeConfig({

--- a/packages/enums-common/vitest.config.ts
+++ b/packages/enums-common/vitest.config.ts
@@ -1,7 +1,5 @@
 import { defineNodeConfig, resolvePackageRoot } from "@repo/vitest-config";
 
-// realpath so Vitest VS Code explorer path walks match its workspace cache
-// (Fatal Error: Attempted to get parent of root folder "/").
 const root = resolvePackageRoot(import.meta.dirname);
 
 export default defineNodeConfig({


### PR DESCRIPTION
Drop prose that only restates an adjacent @internal tag, and delete comments duplicated verbatim across files in favor of documenting the convention once in a rule: the Vitest VS Code realpath rationale (already in quality/vitest-config.md) and the Worker-entry side-effect import convention (newly documented in tests/hono-workers.md, mirrored to .cursor/rules).